### PR TITLE
remove cf2 route that is no longer in Troposphere

### DIFF
--- a/extras/apache/atmo.conf.dist
+++ b/extras/apache/atmo.conf.dist
@@ -124,8 +124,6 @@ ProxyPassReverse  /jenkins  http://MYHOSTNAMEHERE/jenkins
     ProxyPassReverse /forbidden http://localhost:5000/forbidden
     ProxyPass /version http://localhost:5000/version
     ProxyPassReverse /version http://localhost:5000/version
-    ProxyPass /cf2 http://localhost:5000/cf2
-    ProxyPassReverse /cf2 http://localhost:5000/cf2
 
     ProxyPassMatch ^/emulate http://localhost:5000
     ProxyPassReverse /emulate http://localhost:5000


### PR DESCRIPTION
1. Remove the /cf2 route in the apache config.  This is no longer needed now that Troposphere is using a cookie to determine which version of the application should be served to the user.  Both applications are now served from /application.