### PR TITLE
Add maintenance middleware

### DIFF
--- a/atmosphere/maintenance_middleware.py
+++ b/atmosphere/maintenance_middleware.py
@@ -1,0 +1,15 @@
+from django.http import JsonResponse
+
+
+class MaintenanceMiddleware(object):
+    """
+    This middleware returns a 503 when the app is under maintenance for non-admin users
+    """
+    
+    def process_request(self, request):
+        content = {
+            'message': 'Atmosphere is currently under maintenance'
+        }
+        response = JsonResponse(content)
+        response.status_code = 503
+        return response

--- a/atmosphere/maintenance_middleware.py
+++ b/atmosphere/maintenance_middleware.py
@@ -7,9 +7,12 @@ class MaintenanceMiddleware(object):
     """
     
     def process_request(self, request):
-        content = {
-            'message': 'Atmosphere is currently under maintenance'
-        }
-        response = JsonResponse(content)
-        response.status_code = 503
-        return response
+        if request.user.is_staff:
+            return None
+        else:
+            content = {
+                'message': 'Atmosphere is currently under maintenance'
+            }
+            response = JsonResponse(content)
+            response.status_code = 503
+            return response

--- a/atmosphere/maintenance_middleware.py
+++ b/atmosphere/maintenance_middleware.py
@@ -1,4 +1,5 @@
 from django.http import JsonResponse
+from core.models import MaintenanceRecord
 
 
 class MaintenanceMiddleware(object):
@@ -7,12 +8,22 @@ class MaintenanceMiddleware(object):
     """
     
     def process_request(self, request):
+
+        # let staff users through
         if request.user.is_staff:
             return None
-        else:
-            content = {
-                'message': 'Atmosphere is currently under maintenance'
-            }
-            response = JsonResponse(content)
-            response.status_code = 503
-            return response
+
+        # get active maintenance records with no provider specified
+        maintenance_records = MaintenanceRecord.active().filter(provider__isnull=True, disable_login=True)
+
+        # if there are no app disabling records, let users through
+        if maintenance_records.count() == 0:
+            return None
+
+        # return a 503 status code along with the message from the first record
+        content = {
+            'message': maintenance_records.first().message
+        }
+        response = JsonResponse(content)
+        response.status_code = 503
+        return response

--- a/atmosphere/settings/__init__.py
+++ b/atmosphere/settings/__init__.py
@@ -188,6 +188,7 @@ MIDDLEWARE_CLASSES = (
     'pipeline.middleware.MinifyHTMLMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'atmosphere.maintenance_middleware.MaintenanceMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'atmosphere.slash_middleware.RemoveSlashMiddleware',
 )


### PR DESCRIPTION
[lets demo this to team before merging]

This adds middleware to Atmosphere that blocks all API requests from non-staff when Atmosphere is under maintenance.

1. If user is staff, does nothing
2. If user is not staff, gets active maintenance records that have no assigned provider where disable_login is true.
3. If a record matches that description, return a 503 SERVICE UNAVAILABLE status code along with a JSON object that contains the message from the first maintenance record.