### PR TITLE
replace rest_framework_filters with rest_framework.filters

### DIFF
--- a/atmosphere/settings/__init__.py
+++ b/atmosphere/settings/__init__.py
@@ -369,12 +369,10 @@ REST_FRAMEWORK = {
     'PAGINATE_BY': 20,                 # Default to 20
     'PAGINATE_BY_PARAM': 'page_size',  # Allow client to override, using `?page_size=xxx`.
     'MAX_PAGINATE_BY': 100,             # Maximum limit allowed when using `?page_size=xxx`.
-
-    # Disabled on Django 1.8 Until django-filter removes 'related' object
-    #'DEFAULT_FILTER_BACKENDS': (
-    #    'rest_framework_filters.backends.DjangoFilterBackend',
-    #    'rest_framework.filters.SearchFilter'
-    #),
+    'DEFAULT_FILTER_BACKENDS': (
+        'rest_framework.filters.DjangoFilterBackend',
+        'rest_framework.filters.SearchFilter'
+    ),
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
     )


### PR DESCRIPTION
This change finishes restoring the search and query capabilities of the v2 API.

1. Remove the rest_framework_filters backend (DRF extension) and replace with DRF's rest_framework.filter backend.

The rest_framework_filters backend is what was throwing the recent "no module named related".  The fix was made in their master branch (https://github.com/philipn/django-rest-framework-filters/commit/557ebdaf8a64bac7838900586f78cfc5583211b7) but hasn't been updated in their PiPy library through "pip install".

The DRF extension backend provides the ability to make API queries like "image__name__icontains=iplant", where as the standard DRF backend only provides the ability to query "image__name==iplant".

However, since we don't currently need (or expose) any query fields that provide that granularity, I'm opting to replace the package with the standard DRF package instead.

Perhaps later, if we choose to expose more granular search, we can re-evaluate whether the extension package has been updated in PiPy.