### PR TITLE
Refactor Allocation 'exception' message and - timedeltas

### DIFF
--- a/allocation/engine.py
+++ b/allocation/engine.py
@@ -9,9 +9,6 @@ TODO: Refactor #1 - have one AllocationResult PER INSTANCE so that each can be
 
     #TODO: Do we have rules that 'use time' that are NOT
     # directed at instances? (Global?)
-
-
-    #TODO: Include time to zero
 """
 import pytz
 
@@ -110,14 +107,17 @@ def calculate_allocation(allocation, print_logs=False):
             for instance_result in instance_results:
                 logger.debug("> > %s" % instance_result)
         current_period.instance_results = instance_results
-        //TODO: Refactor here - allocation_difference (2-tuple: True/False, Amount over/Under)
+        is_over, diff_amount = current_period.allocation_difference()
         if print_logs:
-            logger.debug("> > %s - %s = %s" %
+            logger.debug("> > %s - %s = %s %s" %
                          (current_period.total_credit,
                           current_period.total_instance_runtime(),
-                          current_period.allocation_difference()))
+                          "-" if is_over else "",
+                          diff_amount))
         if current_result.carry_forward:
-            time_forward = current_period.allocation_difference()
+            # We need to 'carry forward the negative value'
+            # to appropriately 'credit' the next month.
+            time_forward = -diff_amount if is_over else diff_amount
     return current_result
 
 

--- a/allocation/engine.py
+++ b/allocation/engine.py
@@ -110,7 +110,7 @@ def calculate_allocation(allocation, print_logs=False):
             for instance_result in instance_results:
                 logger.debug("> > %s" % instance_result)
         current_period.instance_results = instance_results
-
+        //TODO: Refactor here - allocation_difference (2-tuple: True/False, Amount over/Under)
         if print_logs:
             logger.debug("> > %s - %s = %s" %
                          (current_period.total_credit,

--- a/allocation/models/results.py
+++ b/allocation/models/results.py
@@ -122,6 +122,7 @@ class TimePeriodResult(object):
         Knowing the total allocation, collect total runtime.
         If the difference is LESS THAN//EQUAL to 0, user is OVER Allocation.
         """
+        //TODO: Refactor -- look at first value of 'allocation_difference(2-tuple)'
         return self.allocation_difference() <= timedelta(0)
 
     def allocation_difference(self):
@@ -129,6 +130,7 @@ class TimePeriodResult(object):
         Difference between allocation_credit (Given) and total_runtime (Used)
         """
         total_runtime = self.total_instance_runtime()
+        //TODO: Refactor -- first value (True,False (if value is negative), Abs(value))
         return self.total_credit - total_runtime
 
     def increase_credit(self, credit_amount, carry_forward=False):
@@ -234,6 +236,7 @@ class AllocationResult():
         return self.last_period().time_to_zero()
 
     def total_difference(self):
+        //TODO: Refactor to the (2-tuple) method
         if self.carry_forward:
             return self.last_period().allocation_difference()
         difference = timedelta(0)

--- a/allocation/tests.py
+++ b/allocation/tests.py
@@ -306,12 +306,14 @@ class AllocationTestCase(unittest.TestCase):
         self.assertEqual(allocation_result.total_runtime(), total_runtime)
         return self
 
-    def assertDifferenceEquals(self, allocation, difference):
+    def assertDifferenceEquals(self, allocation, is_over_allocation, difference):
         """
         Assert that the difference and the allocation matches
         """
         allocation_result = self._calculate_allocation(allocation)
-        self.assertEquals(allocation_result.total_difference(), difference)
+        is_over, diff_amount = allocation_result.total_difference()
+        self.assertEquals(is_over, is_over_allocation)
+        self.assertEquals(diff_amount, difference)
         return self
 
 

--- a/core/models/group.py
+++ b/core/models/group.py
@@ -130,16 +130,14 @@ class IdentityMembership(models.Model):
         from service.monitoring import get_delta, _get_allocation_result
         delta = get_delta(self, time_period=settings.FIXED_WINDOW)
         allocation_result = _get_allocation_result(self.identity)
-
+        over_allocation, diff_amount = allocation_result.total_difference()
         burn_time = allocation_result.get_burn_rate()
         #Moving from seconds to hours
         hourly_credit = int(allocation_result\
                 .total_credit().total_seconds()/3600.0)
         hourly_runtime = int(allocation_result\
                 .total_runtime().total_seconds()/3600.0)
-        hourly_difference = int(allocation_result\
-                .total_difference().total_seconds()/3600.0)
-
+        hourly_difference = int(diff_amount.total_seconds()/3600.0)
         zero_time = allocation_result.time_to_zero()
 
         allocation_dict = {

--- a/service/exceptions.py
+++ b/service/exceptions.py
@@ -34,11 +34,11 @@ class HypervisorCapacityError(Exception):
 
 class OverAllocationError(Exception):
 
-    def __init__(self, wait_timedelta):
-        self.wait_timedelta = wait_timedelta
-        self.message = "Time allocation exceeded. "\
-            "Wait %s before requesting new resources"\
-            % (self.wait_timedelta)
+    def __init__(self, amount_exceeded):
+        self.overage = amount_exceeded
+        self.message = "Time allocation exceeded: Instance usage is over by "\
+            "%s."\
+            % (self.overage,)
         super(OverAllocationError, self).__init__(self.message)
 
     def __str__(self):

--- a/service/monitoring.py
+++ b/service/monitoring.py
@@ -163,13 +163,14 @@ def user_over_allocation_enforcement(
         return allocation_result
 
     # Enforce allocation if overboard.
-    if allocation_result.over_allocation():
+    over_allocation, diff_amount = allocation_result.total_difference()
+    if over_allocation:
         logger.info(
             "%s is OVER allocation. %s - %s = %s"
             % (username,
                allocation_result.total_credit(),
                allocation_result.total_runtime(),
-               allocation_result.total_difference()))
+               diff_amount))
         enforce_allocation_policy(identity, user)
     return allocation_result
 
@@ -382,12 +383,12 @@ def check_over_allocation(username, identity_uuid,
     """
     Check if an identity is over allocation.
 
-    True if allocation has been exceeded, otherwise False.
+    True,False - Over/Under Allocation
+    Amount - Time (amount) Over/Under Allocation.
     """
     identity = Identity.objects.get(uuid=identity_uuid)
     allocation_result = _get_allocation_result(identity)
-    return (allocation_result.over_allocation(),
-            allocation_result.total_difference())
+    return allocation_result.total_difference()
 
 
 def get_allocation(username, identity_uuid):


### PR DESCRIPTION
As it turns out, - timedelta's are quite confusing to 'humans'..

For example, humans understand: 1 hour, 30 minutes OVER your allotted allocation.
Humans do NOT understand: -1 days, 22 hours, 30 minutes OVER your allotted allocation.

To remedy this, we treat timedeltas as a 'positive-only' value, accompanied by a 'is_over (allocation)' boolean value to indicate whether that time should be considered "The amount OVER allocation" or "The amount UNDER allocation"