### PR TITLE
Add two more attributes to /v2/instance_history objects

### DIFF
--- a/api/v2/serializers/details/instance_history.py
+++ b/api/v2/serializers/details/instance_history.py
@@ -1,36 +1,33 @@
 from rest_framework import serializers
 
-from core.models import Instance, InstanceStatusHistory, Size, Provider, Application as Image
+from core.models import Instance, InstanceStatusHistory, Size
 
 from api.v2.serializers.summaries import (
-    InstanceSuperSummarySerializer, ProviderSummarySerializer, ImageSummarySerializer)
+    InstanceSuperSummarySerializer,
+    ProviderSummarySerializer, ImageSummarySerializer)
 from api.v2.serializers.summaries.size import SizeRelatedField
-from api.v2.serializers.fields import ModelRelatedField
+
 
 class InstanceRelatedField(serializers.PrimaryKeyRelatedField):
 
     def to_representation(self, value):
         instance = Instance.objects.get(pk=value.pk)
-        # important! We have to use the SuperSummary because there are non-end_dated
+        # important! We have to use the SuperSummary
+        # because there are non-end_dated
         # instances that don't have a valid size (size='Unknown')
         serializer = InstanceSuperSummarySerializer(
             instance,
             context=self.context)
         return serializer.data
 
+
 class InstanceStatusHistorySerializer(serializers.HyperlinkedModelSerializer):
     instance = InstanceRelatedField(queryset=Instance.objects.none())
     size = SizeRelatedField(queryset=Size.objects.none())
-    provider = ModelRelatedField(
-        source='instance.provider_machine.provider',
-        queryset=Provider.objects.all(),
-        serializer_class=ProviderSummarySerializer,
-        style={'base_template': 'input.html'})
-    image = ModelRelatedField(
-        source='instance.provider_machine.application_version.application',
-        queryset=Image.objects.all(),
-        serializer_class=ImageSummarySerializer,
-        style={'base_template': 'input.html'})
+    provider = ProviderSummarySerializer(
+        source='instance.provider_machine.provider')
+    image = ImageSummarySerializer(
+        source='instance.provider_machine.application_version.application')
     status = serializers.SlugRelatedField(slug_field='name', read_only=True)
 
     class Meta:

--- a/api/v2/serializers/details/instance_history.py
+++ b/api/v2/serializers/details/instance_history.py
@@ -1,9 +1,11 @@
 from rest_framework import serializers
 
-from core.models import Instance, InstanceStatusHistory, Size
+from core.models import Instance, InstanceStatusHistory, Size, Provider, Application as Image
 
-from api.v2.serializers.summaries import InstanceSuperSummarySerializer
+from api.v2.serializers.summaries import (
+    InstanceSuperSummarySerializer, ProviderSummarySerializer, ImageSummarySerializer)
 from api.v2.serializers.summaries.size import SizeRelatedField
+from api.v2.serializers.fields import ModelRelatedField
 
 class InstanceRelatedField(serializers.PrimaryKeyRelatedField):
 
@@ -19,6 +21,16 @@ class InstanceRelatedField(serializers.PrimaryKeyRelatedField):
 class InstanceStatusHistorySerializer(serializers.HyperlinkedModelSerializer):
     instance = InstanceRelatedField(queryset=Instance.objects.none())
     size = SizeRelatedField(queryset=Size.objects.none())
+    provider = ModelRelatedField(
+        source='instance.provider_machine.provider',
+        queryset=Provider.objects.all(),
+        serializer_class=ProviderSummarySerializer,
+        style={'base_template': 'input.html'})
+    image = ModelRelatedField(
+        source='instance.provider_machine.application_version.application',
+        queryset=Image.objects.all(),
+        serializer_class=ImageSummarySerializer,
+        style={'base_template': 'input.html'})
     status = serializers.SlugRelatedField(slug_field='name', read_only=True)
 
     class Meta:
@@ -30,6 +42,8 @@ class InstanceStatusHistorySerializer(serializers.HyperlinkedModelSerializer):
             'instance',
             'status',
             'size',
+            'provider',
+            'image',
             'start_date',
             'end_date',
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ django-celery==3.1.16
 gevent==1.0.1
 
 apache-libcloud==0.16.0
-requests==2.2
+requests==2.7
 python-dateutil==1.4.1
 pytz==2015.4
 Pillow==2.5.3
@@ -36,7 +36,7 @@ uWSGI==2.0.9
 ## ours
 threepio==0.2.0
 rtwo==0.2.14
-caslib.py==2.2.0
+caslib.py==2.2.2
 chromogenic==0.1.7
 jwt.py==0.1.0
 subspace==0.1.6


### PR DESCRIPTION
Added 'image' and 'provider' to instance history to avoid deep-nested queries clientside. See https://github.com/iPlantCollaborativeOpenSource/troposphere/pull/126 for details on how this changed the UI implementation.