### PR TITLE
Include 'Monitor machines' as a periodic task

### DIFF
--- a/api/v2/views/image_version.py
+++ b/api/v2/views/image_version.py
@@ -1,32 +1,9 @@
-from django.db.models import Q
-from django.contrib.auth.models import AnonymousUser
-
 from rest_framework import filters
 import django_filters
 
 from core.models import ApplicationVersion as ImageVersion
-from core.models import AccountProvider
-from core.query import only_current_machines_in_version, only_current
-
 from api.v2.views.base import AuthOptionalViewSet
 from api.v2.serializers.details import ImageVersionSerializer
-
-
-def get_admin_image_versions(user):
-    """
-    TODO: This 'just works' and is probably very slow... Look for a better way?
-    """
-    provider_id_list = user.identity_set.values_list('provider', flat=True)
-    account_providers_list = AccountProvider.objects.filter(
-        provider__id__in=provider_id_list)
-    admin_users = [ap.identity.created_by for ap in account_providers_list]
-    version_ids = []
-    for user in admin_users:
-        version_ids.extend(
-            user.applicationversion_set.values_list('id', flat=True))
-    admin_list = ImageVersion.objects.filter(
-        id__in=version_ids)
-    return admin_list
 
 
 class ImageFilter(django_filters.FilterSet):

--- a/core/models/instance.py
+++ b/core/models/instance.py
@@ -249,8 +249,6 @@ class Instance(models.Model):
         """
         import traceback
         # 1. Get status name
-        logger.debug("STATUSUPDATE - Instance:%s Old Status: %s New Status: %s Tmp Status: %s" % (self.provider_alias, self.esh_status(), status_name, tmp_status))
-        logger.debug("STATUSUPDATE - Traceback: %s" % traceback.format_stack())
         status_name = _get_status_name_for_provider(
             self.provider_machine.provider,
             status_name,
@@ -262,13 +260,16 @@ class Instance(models.Model):
             last_history = InstanceStatusHistory.create_history(
                 status_name, self, size, self.start_date)
             last_history.save()
-            logger.debug("First Status history: %s" % last_history)
+            logger.debug("STATUSUPDATE - FIRST - Instance:%s Old Status: %s New Status: %s Tmp Status: %s" % (self.provider_alias, self.esh_status(), status_name, tmp_status))
+            logger.debug("STATUSUPDATE - Traceback: %s" % traceback.format_stack())
         # 2. Size and name must match to continue using last history
         if last_history.status.name == status_name \
                 and last_history.size.id == size.id:
             # logger.info("status_name matches last history:%s " %
             #        last_history.status.name)
             return (False, last_history)
+        logger.debug("STATUSUPDATE - Instance:%s Old Status: %s New Status: %s Tmp Status: %s" % (self.provider_alias, self.esh_status(), status_name, tmp_status))
+        logger.debug("STATUSUPDATE - Traceback: %s" % traceback.format_stack())
         # 3. ASSERT: A new history item is required due to a State or Size
         # Change
         now_time = timezone.now()

--- a/core/models/machine.py
+++ b/core/models/machine.py
@@ -217,7 +217,7 @@ def get_or_create_provider_machine(image_id, machine_name,
     if not version:
         version = get_version_for_machine(provider_uuid, image_id)
     if not version:
-        version = create_app_version(app, "1.0")
+        version = create_app_version(app, "1.0", provider_machine_id=image_id)
 
     return create_provider_machine(
         image_id,

--- a/core/models/machine.py
+++ b/core/models/machine.py
@@ -136,8 +136,8 @@ class ProviderMachine(BaseSource):
     def __unicode__(self):
         identifier = self.instance_source.identifier
         provider = self.instance_source.provider
-        return "%s (Provider:%s - App:%s) " %\
-            (identifier, provider, self.application)
+        return "%s (Provider:%s - App:%s Version:%s) " %\
+            (identifier, provider, self.application, self.application_version.name)
 
     class Meta:
         db_table = "provider_machine"

--- a/core/query.py
+++ b/core/query.py
@@ -134,6 +134,17 @@ def only_current_source(now_time=None):
         now_time = timezone.now()
     return _in_range() & _active_provider()
 
+def source_in_range(now_time=None):
+    """
+    Filters current instance_sources ignoring provider.
+    """
+    def _in_range():
+        return (Q(instance_source__end_date__isnull=True) |
+                Q(instance_source__end_date__gt=now_time)) &\
+            Q(instance_source__start_date__lt=now_time)
+    if not now_time:
+        now_time = timezone.now()
+    return _in_range()
 
 def only_current(now_time=None):
     """

--- a/extras/init.d/atmosphere.uwsgi+nginx
+++ b/extras/init.d/atmosphere.uwsgi+nginx
@@ -96,6 +96,8 @@ stop)
         echo "You must be a root user to stop atmosphere"
         exit 1
     fi
+    printf "Stopping uwsgi..\n"
+    service uwsgi stop
     printf "Stopping $WEB_SERVICE\n"
     service $WEB_SERVICE stop
     printf "Stopping Celery..\n"

--- a/service/tasks/monitoring.py
+++ b/service/tasks/monitoring.py
@@ -327,7 +327,7 @@ def _share_image(account_driver, cloud_machine, identity, members, dry_run=False
         logger.info("Making Machine %s private" % cloud_machine.id)
         cloud_machine.update(is_public=False)
 
-    logger.info("Sharing image %s : %s with %s" % (cloud_machine.id, identity.provider.location, tenant_name.value))
+    logger.info("Sharing image %s<%s>: %s with %s" % (cloud_machine.id, cloud_machine.name, identity.provider.location, tenant_name.value))
     if not dry_run:
         account_driver.image_manager.share_image(cloud_machine, tenant_name.value)
 

--- a/service/tasks/monitoring.py
+++ b/service/tasks/monitoring.py
@@ -5,7 +5,7 @@ from django.db.models import Q
 
 from celery.decorators import task
 
-from core.query import only_current, only_current_machines, only_current_apps, only_current_source
+from core.query import only_current, only_current_machines, only_current_apps, only_current_source, source_in_range
 from core.models.size import Size, convert_esh_size
 from core.models.instance import convert_esh_instance
 from core.models.provider import Provider
@@ -96,9 +96,10 @@ def prune_machines_for(provider_id, print_logs=False, dry_run=False, forced_remo
         all_projects_map = tenant_id_to_name_map(account_driver)
         cloud_machines = account_driver.list_all_images()
     else:
-        db_machines = ProviderMachine.objects.filter(instance_source__provider=provider)
+        db_machines = ProviderMachine.objects.filter(
+                source_in_range(),
+                instance_source__provider=provider)
         cloud_machines = []
-
     # Don't do anything if cloud machines == [None,[]]
     if not cloud_machines and not forced_removal:
         return


### PR DESCRIPTION
For the incana-incana release..

use 'prune_machines' to end date images that have been deleted out of band.
use 'monitor_machines' to 'pull in' images that have been created out of band, and update sharing (both on the DB and on the cloud) to reflect the user's privacy choices. 