### PR TITLE
A call to is_valid on a serializer shouldn't have side effects.

### DIFF
--- a/api/v1/serializers/atmo_user_serializer.py
+++ b/api/v1/serializers/atmo_user_serializer.py
@@ -24,13 +24,9 @@ class AtmoUserSerializer(serializers.ModelSerializer):
         for g in groups:
             for id_member in g.identitymembership_set.all():
                 if id_member.identity == selected_identity:
-                    logger.info("Saving new identity:%s" % selected_identity)
-                    user.selected_identity = selected_identity
-                    user.save()
                     return selected_identity
-        raise serializers.ValidationError("User is not a member of"
-                                          "selected_identity: %s"
-                                          % selected_identity)
+        raise serializers.ValidationError( 
+                "User is not a member of selected_identity: %s" % selected_identity)
 
     class Meta:
         model = AtmosphereUser


### PR DESCRIPTION
This change shouldn't have any negative effects on the code base. [Here](https://github.com/iPlantCollaborativeOpenSource/atmosphere/blob/bf8854654638a0e4473432087bf9d07475d1b65a/api/v1/views/profile.py#L45-L49) is the code that uses this modified serializer. 
