### PR TITLE
Add POST to Allocation method list

### DIFF
--- a/api/v2/views/allocation.py
+++ b/api/v2/views/allocation.py
@@ -12,4 +12,4 @@ class AllocationViewSet(AuthViewSet):
 
     queryset = Allocation.objects.all()
     serializer_class = AllocationSerializer
-    http_method_names = ['get', 'head', 'options', 'trace']
+    http_method_names = ['post', 'get', 'head', 'options', 'trace']


### PR DESCRIPTION
This is necessary for https://github.com/iPlantCollaborativeOpenSource/troposphere/pull/193.

Creation of new allocation objects is necessary for assigning allocations that do not yet exist.