### PR TITLE
Include basic account bootstrapping for newly authenticated users.

### DIFF
--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -18,7 +18,11 @@ ENFORCING = True
 ENFORCING = False
 {% endif %}
 
-
+{% if AUTO_CREATE_NEW_ACCOUNTS %}
+AUTO_CREATE_NEW_ACCOUNTS = True
+{% else %}
+AUTO_CREATE_NEW_ACCOUNTS = False
+{% endif %}
 # Logging
 LOGGING_LEVEL = {{ LOGGING_LEVEL }}
 # Logging level for dependencies.

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -1,6 +1,7 @@
 import uuid
 
 from django.contrib.auth.models import AbstractUser
+from django.conf import settings
 from django.db import models
 from django.db.models import Q
 from django.db.models.signals import post_save
@@ -127,6 +128,11 @@ def get_default_identity(username, provider=None):
     try:
         from core.models.group import get_user_group
         group = get_user_group(username)
+        if not group or not group.current_identities.all().count():
+            if settings.AUTO_CREATE_NEW_ACCOUNTS:
+                return create_first_identity(username, provider=provider)
+            else:
+                return None
         identities = group.current_identities.all()
         if provider:
             if provider.is_active():
@@ -142,7 +148,7 @@ def get_default_identity(username, provider=None):
                 provider=default_provider)
             if not default_identity:
                 logger.error("User %s has no identities on Provider %s" % (username, default_provider))
-                raise "No Identities on Provider %s for %s" % (default_provider,username)
+                raise Exception("No Identities on Provider %s for %s" % (default_provider, username))
             #Passing
             default_identity = default_identity[0]
             logger.debug(
@@ -152,3 +158,23 @@ def get_default_identity(username, provider=None):
     except Exception as e:
         logger.exception(e)
         return None
+
+def create_first_identity(username, provider=None):
+    from service.driver import get_account_driver
+    user = AtmosphereUser.objects.get(username=username)
+    if not provider:
+        provider = get_available_provider()
+    if not provider:
+        raise Exception("No currently active providers -- Could not create First identity")
+    accounts = get_account_driver(provider)
+    new_identity = accounts.create_account(user.username)
+    return new_identity
+
+def get_available_provider():
+    from core.models.provider import Provider
+    from core.query import only_current
+    available_providers = Provider.objects.filter(only_current(), active=True).order_by('id')
+    if not available_providers.count():
+        return None
+    # Strategy, for now, is to just pick the first one.
+    return available_providers[0]


### PR DESCRIPTION
Create a new setting to control whether or not the first identity should be auto-created for a user that has been deemed authorized into Atmosphere. This is a stop-gap measure, and this feature will be fleshed out at a later point in time to include which provider should/should not be used, what quota and allocation should be assigned to new users, etc.