### PR TITLE
Small fixes

### DIFF
--- a/extras/init.d/celeryd.default.dist.j2
+++ b/extras/init.d/celeryd.default.dist.j2
@@ -95,8 +95,6 @@ CELERYD_MAX_TASKS_PER_CHILD="150"
 CELERYD_FLOWER="$CELERYD_CHDIR/manage.py celery flower"
 ADMIN_USER="flower_user"
 ADMIN_PASS="flower_pass"
-#Possibly not necessary?
-FLOWER_BROKER_OPT="--broker=amqp://broker_user:broker_pass@hostname:5672/virtualhost_name"
 #TODO:Change to Google+OAUTH2 VERY soon!
 FLOWER_AUTH_OPT="--basic_auth=$ADMIN_USER:$ADMIN_PASS"
 OAUTH2_ACCESS_LIST=""

--- a/service/instance.py
+++ b/service/instance.py
@@ -1534,7 +1534,7 @@ def run_instance_volume_action(user, identity, esh_driver, esh_instance, action_
             raise VolumeAttachConflict(
                 message='Instance %s must be active before attaching '
                 'a volume. '
-                'Retry request when volume is active.'
+                'Retry request when instance is active.'
                 % (instance_id,))
         result = task.attach_volume_task(
                 esh_driver, esh_instance.alias,


### PR DESCRIPTION
The flower broker url is not what flowers like :tulip:. See @steve-gregory for a good reason why it breaks celery/flower.

The second small fix is for an incorrect error message.