### PR TITLE
Create a base viewset for both APIs (Version, DeployVersion)

### DIFF
--- a/api/base/views.py
+++ b/api/base/views.py
@@ -1,8 +1,8 @@
 """
-Atmosphere API version service.
+Atmosphere API Common/Base views.
 
 """
-from rest_framework.views import APIView
+from rest_framework import viewsets, mixins
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 
@@ -15,11 +15,12 @@ except ImportError:
 from api.permissions import InMaintenance
 
 
-class Version(APIView):
+class VersionViewSet(mixins.ListModelMixin,
+                     viewsets.GenericViewSet):
     permission_classes = (IsAuthenticatedOrReadOnly,
                           InMaintenance)
 
-    def get(self, request, format=None):
+    def list(self, request, *args, **kwargs):
         """
         This request will retrieve Atmosphere's version,
         including the latest update to the code base and the date the
@@ -27,11 +28,13 @@ class Version(APIView):
         """
         return Response(get_version("all"))
 
-class DeployVersion(APIView):
+
+class DeployVersionViewSet(mixins.ListModelMixin,
+                           viewsets.GenericViewSet):
     permission_classes = (IsAuthenticatedOrReadOnly,
                           InMaintenance)
 
-    def get(self, request, format=None):
+    def list(self, request, format=None):
         """
         This request will retrieve Atmosphere's version,
         including the latest update to the code base and the date the

--- a/api/v1/urls.py
+++ b/api/v1/urls.py
@@ -7,6 +7,7 @@ from django.conf.urls import patterns, url
 from rest_framework.urlpatterns import format_suffix_patterns
 
 from api.v1 import views
+from api.base import views as base_views
 # Regex matching you'll use everywhere..
 id_match = '\d+'
 uuid_match = '[a-zA-Z0-9-]+'
@@ -197,8 +198,8 @@ urlpatterns = format_suffix_patterns(patterns(
         views.QuotaDetail.as_view(), name='quota-detail'),
 
 
-    url(r'^version$', views.Version.as_view()),
-    url(r'^deploy_version$', views.DeployVersion.as_view()),
+    url(r'^version$', base_views.VersionViewSet.as_view({'get':'list'}), name='v1-atmo'),
+    url(r'^deploy_version$', base_views.DeployVersionViewSet.as_view({'get':'list'}), name='v1-deploy'),
     url(r'^maintenance$',
         views.MaintenanceRecordList.as_view(),
         name='maintenance-record-list'),

--- a/api/v1/views/__init__.py
+++ b/api/v1/views/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from api.v1.views.allocation import AllocationDetail, AllocationList, MonitoringList
 from api.v1.views.cloud_admin import\
     CloudAdminImagingRequestList, CloudAdminImagingRequest,\
@@ -35,7 +36,6 @@ from api.v1.views.size import SizeList, Size
 from api.v1.views.hypervisor import HypervisorList, HypervisorDetail
 from api.v1.views.tag import TagList, Tag
 from api.v1.views.token import TokenEmulate
-from api.v1.views.version import Version, DeployVersion
 from api.v1.views.volume import BootVolume,\
     VolumeSnapshot, VolumeSnapshotDetail,\
     VolumeList, Volume

--- a/api/v2/urls.py
+++ b/api/v2/urls.py
@@ -5,6 +5,7 @@ Routes for api v2 endpoints
 from django.conf.urls import patterns, include, url
 from rest_framework import routers
 from api.v2 import views
+from api.base import views as base_views
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(
@@ -67,6 +68,8 @@ router.register(r'tokens', views.TokenViewSet, base_name='token')
 router.register(r'users', views.UserViewSet)
 router.register(r'groups', views.GroupViewSet, base_name='group')
 router.register(r'volumes', views.VolumeViewSet, base_name='volume')
+router.register(r'version', base_views.VersionViewSet, base_name='version-atmo')
+router.register(r'deploy_version', base_views.DeployVersionViewSet, base_name='version-deploy')
 
 api_v2_urls = router.urls
 urlpatterns = patterns('', url(r'^', include(api_v2_urls)),)


### PR DESCRIPTION
[JIRA] (https://pods.iplantcollaborative.org/jira/browse/ATMO-606).
[Troposphere PR] (https://github.com/iPlantCollaborativeOpenSource/troposphere/pull/216).

Adds a 'Version' (for Atmosphere) and DeployVersion (for atmosphere-ansible) that can be queried to help the end user find out what SHA the current API is based from.