### PR TITLE
Respond with 409 and inform user when a Provider is Inactive

### DIFF
--- a/api/email.py
+++ b/api/email.py
@@ -21,7 +21,7 @@ from service.volume import create_volume
 from service.exceptions import OverQuotaError
 
 from api.serializers import VolumeSerializer
-from api import prepare_driver, failure_response, invalid_creds
+from api import failure_response, invalid_creds
 
 from web.emails import feedback_email, quota_request_email, support_email
 

--- a/api/exceptions.py
+++ b/api/exceptions.py
@@ -24,7 +24,6 @@ def malformed_response(provider_id, identity_id):
         "Cloud Communications Error --"
         " Contact your Cloud Administrator OR try again later!")
 
-
 def invalid_provider(provider_id):
     log_message = 'Provider %s is inactive, disabled, or does not exist.'\
         % (provider_id, )
@@ -76,6 +75,12 @@ def size_not_available(sna_exception):
     return failure_response(
         status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
         sna_exception.message)
+
+
+def inactive_provider(provider_exception):
+    return failure_response(
+        status.HTTP_409_CONFLICT,
+        provider_exception.message)
 
 
 def over_capacity(capacity_exception):

--- a/api/v1/views/hypervisor.py
+++ b/api/v1/views/hypervisor.py
@@ -10,7 +10,7 @@ from rest_framework import status
 
 from core.models import Provider
 
-from service.driver import prepare_driver, get_admin_driver
+from service.driver import get_admin_driver
 
 from api import invalid_creds, connection_failure, failure_response
 from api.v1.views.base import AuthAPIView

--- a/api/v1/views/identity.py
+++ b/api/v1/views/identity.py
@@ -7,7 +7,7 @@ from core.models.group import Group
 from core.models.identity import Identity as CoreIdentity
 from core.models.provider import Provider
 
-from api import failure_response, invalid_provider, invalid_provider_identity
+from api import failure_response, invalid_provider, invalid_provider_identity,
 from api.v1.serializers import IdentitySerializer, IdentityDetailSerializer
 from api.v1.views.base import AuthAPIView
 

--- a/api/v1/views/identity.py
+++ b/api/v1/views/identity.py
@@ -1,13 +1,13 @@
+from rest_framework import status
 from rest_framework.response import Response
 
 from threepio import logger
 
-from core.query import only_current_provider
 from core.models.group import Group
 from core.models.identity import Identity as CoreIdentity
 from core.models.provider import Provider
 
-from api import failure_response, invalid_provider, invalid_provider_identity,
+from api import failure_response, invalid_provider, invalid_provider_identity
 from api.v1.serializers import IdentitySerializer, IdentityDetailSerializer
 from api.v1.views.base import AuthAPIView
 
@@ -49,7 +49,7 @@ def get_identity_list(user, provider=None):
         logger.warn("Group %s DoesNotExist" % user.username)
         return None
     except CoreIdentity.DoesNotExist:
-        logger.warn("Identity %s DoesNotExist" % identity_uuid)
+        logger.warn("Identity DoesNotExist for user %s" % user.username)
         return None
 
 

--- a/api/v1/views/occupancy.py
+++ b/api/v1/views/occupancy.py
@@ -13,7 +13,7 @@ from rest_framework.response import Response
 from core.models.provider import Provider
 from core.models.size import convert_esh_size
 
-from service.driver import get_esh_driver, get_admin_driver
+from service.driver import get_admin_driver
 
 from api import failure_response
 from api import connection_failure

--- a/api/v1/views/size.py
+++ b/api/v1/views/size.py
@@ -4,7 +4,9 @@ Atmosphere api size.
 from django.utils import timezone
 
 from rest_framework.response import Response
+from rest_framework import status
 
+from core.exceptions import ProviderNotActive
 from core.models.size import convert_esh_size
 
 from service.driver import prepare_driver
@@ -14,6 +16,7 @@ from socket import error as socket_error
 from rtwo.exceptions import ConnectionFailure
 
 from api import invalid_creds, malformed_response, connection_failure
+from api.exceptions import inactive_provider, failure_response
 from api.v1.serializers import ProviderSizeSerializer
 from api.v1.views.base import AuthAPIView
 
@@ -32,7 +35,15 @@ class SizeList(AuthAPIView):
         # TODO: Decide how we should pass this in (I.E. GET query string?)
         active = False
         user = request.user
-        esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        try:
+            esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        except ProviderNotActive as pna:
+            return inactive_provider(pna)
+        except Exception as e:
+            return failure_response(
+                status.HTTP_409_CONFLICT,
+                e.message)
+
         if not esh_driver:
             return invalid_creds(provider_uuid, identity_uuid)
         try:
@@ -64,7 +75,15 @@ class Size(AuthAPIView):
         Update on server DB (If applicable)
         """
         user = request.user
-        esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        try:
+            esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        except ProviderNotActive as pna:
+            return inactive_provider(pna)
+        except Exception as e:
+            return failure_response(
+                status.HTTP_409_CONFLICT,
+                e.message)
+
         if not esh_driver:
             return invalid_creds(provider_uuid, identity_uuid)
         core_size = convert_esh_size(

--- a/api/v1/views/volume.py
+++ b/api/v1/views/volume.py
@@ -13,6 +13,9 @@ from libcloud.common.types import InvalidCredsError, MalformedResponseError
 
 from threepio import logger
 
+from api.exceptions import failure_response, inactive_provider
+
+from core.exceptions import ProviderNotActive
 from core.models.identity import Identity
 from core.models.instance import convert_esh_instance
 from core.models.provider import AccountProvider
@@ -43,7 +46,14 @@ class VolumeSnapshot(AuthAPIView):
     def get(self, request, provider_uuid, identity_uuid):
         """
         """
-        esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        try:
+            esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        except ProviderNotActive as pna:
+            return inactive_provider(pna)
+        except Exception as e:
+            return failure_response(
+                status.HTTP_409_CONFLICT,
+                e.message)
         if not esh_driver:
             return invalid_creds(provider_uuid, identity_uuid)
         try:
@@ -85,7 +95,14 @@ class VolumeSnapshot(AuthAPIView):
         metadata = data.get('metadata')
         snapshot_id = data.get('snapshot_id')
         # STEP 0 - Existence tests
-        esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        try:
+            esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        except ProviderNotActive as pna:
+            return inactive_provider(pna)
+        except Exception as e:
+            return failure_response(
+                status.HTTP_409_CONFLICT,
+                e.message)
         if not esh_driver:
             return invalid_creds(provider_uuid, identity_uuid)
         try:
@@ -158,7 +175,14 @@ class VolumeSnapshotDetail(AuthAPIView):
     def get(self, request, provider_uuid, identity_uuid, snapshot_id):
         """
         """
-        esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        try:
+            esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        except ProviderNotActive as pna:
+            return inactive_provider(pna)
+        except Exception as e:
+            return failure_response(
+                status.HTTP_409_CONFLICT,
+                e.message)
         if not esh_driver:
             return invalid_creds(provider_uuid, identity_uuid)
         snapshot = esh_driver._connection.get_snapshot(snapshot_id)
@@ -172,7 +196,14 @@ class VolumeSnapshotDetail(AuthAPIView):
         Destroys the volume and updates the DB
         """
         # Ensure volume exists
-        esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        try:
+            esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        except ProviderNotActive as pna:
+            return inactive_provider(pna)
+        except Exception as e:
+            return failure_response(
+                status.HTTP_409_CONFLICT,
+                e.message)
         if not esh_driver:
             return invalid_creds(provider_uuid, identity_uuid)
         snapshot = esh_driver._connection.get_snapshot(snapshot_id)
@@ -197,7 +228,14 @@ class VolumeList(AuthAPIView):
         Retrieves list of volumes and updates the DB
         """
         user = request.user
-        esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        try:
+            esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        except ProviderNotActive as pna:
+            return inactive_provider(pna)
+        except Exception as e:
+            return failure_response(
+                status.HTTP_409_CONFLICT,
+                e.message)
         if not esh_driver:
             return invalid_creds(provider_uuid, identity_uuid)
         volume_list_method = esh_driver.list_volumes
@@ -232,7 +270,14 @@ class VolumeList(AuthAPIView):
         Creates a new volume and adds it to the DB
         """
         user = request.user
-        driver = prepare_driver(request, provider_uuid, identity_uuid)
+        try:
+            esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        except ProviderNotActive as pna:
+            return inactive_provider(pna)
+        except Exception as e:
+            return failure_response(
+                status.HTTP_409_CONFLICT,
+                e.message)
         if not driver:
             return invalid_creds(provider_uuid, identity_uuid)
         data = request.data
@@ -295,7 +340,15 @@ class Volume(AuthAPIView):
         """
         """
         user = request.user
-        esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        try:
+            esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        except ProviderNotActive as pna:
+            return inactive_provider(pna)
+        except Exception as e:
+            return failure_response(
+                status.HTTP_409_CONFLICT,
+                e.message)
+
         if not esh_driver:
             return invalid_creds(provider_uuid, identity_uuid)
         try:
@@ -333,7 +386,15 @@ class Volume(AuthAPIView):
         user = request.user
         data = request.data
         # Ensure volume exists
-        esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        try:
+            esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        except ProviderNotActive as pna:
+            return inactive_provider(pna)
+        except Exception as e:
+            return failure_response(
+                status.HTTP_409_CONFLICT,
+                e.message)
+
         if not esh_driver:
             return invalid_creds(provider_uuid, identity_uuid)
         try:
@@ -373,7 +434,15 @@ class Volume(AuthAPIView):
         data = request.data
 
         # Ensure volume exists
-        esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        try:
+            esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        except ProviderNotActive as pna:
+            return inactive_provider(pna)
+        except Exception as e:
+            return failure_response(
+                status.HTTP_409_CONFLICT,
+                e.message)
+
         if not esh_driver:
             return invalid_creds(provider_uuid, identity_uuid)
         try:
@@ -410,7 +479,15 @@ class Volume(AuthAPIView):
         """
         user = request.user
         # Ensure volume exists
-        esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        try:
+            esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+        except ProviderNotActive as pna:
+            return inactive_provider(pna)
+        except Exception as e:
+            return failure_response(
+                status.HTTP_409_CONFLICT,
+                e.message)
+
         if not esh_driver:
             return invalid_creds(provider_uuid, identity_uuid)
         try:

--- a/api/v1/views/volume.py
+++ b/api/v1/views/volume.py
@@ -16,22 +16,18 @@ from threepio import logger
 from api.exceptions import failure_response, inactive_provider
 
 from core.exceptions import ProviderNotActive
-from core.models.identity import Identity
-from core.models.instance import convert_esh_instance
 from core.models.provider import AccountProvider
 from core.models.volume import convert_esh_volume
 from core.models.volume import Volume as CoreVolume
 from core.models.instance_source import InstanceSource
 
-from service.cache import get_cached_volumes
 from service.driver import prepare_driver
 from service.volume import create_volume,\
     create_bootable_volume,\
     _update_volume_metadata
 from service.exceptions import OverQuotaError
-from service.volume import create_volume
 
-from api import failure_response, invalid_creds, connection_failure,\
+from api import invalid_creds, connection_failure,\
     malformed_response
 from api.v1.serializers import VolumeSerializer, InstanceSerializer
 from api.v1.views.base import AuthAPIView
@@ -271,7 +267,7 @@ class VolumeList(AuthAPIView):
         """
         user = request.user
         try:
-            esh_driver = prepare_driver(request, provider_uuid, identity_uuid)
+            driver = prepare_driver(request, provider_uuid, identity_uuid)
         except ProviderNotActive as pna:
             return inactive_provider(pna)
         except Exception as e:
@@ -551,7 +547,7 @@ class BootVolume(AuthAPIView):
         try:
             core_instance = create_bootable_volume(
                 request.user, provider_uuid, identity_uuid,
-                name, size_id, source_alias, source_hint=key_name,
+                name, size_id, volume_id, source_hint=key_name,
                 **data)
         except Exception as exc:
             message = exc.message

--- a/api/v2/views/instance.py
+++ b/api/v2/views/instance.py
@@ -2,6 +2,7 @@ from api.v2.serializers.details import InstanceSerializer
 from api.v2.serializers.post import InstanceSerializer as POST_InstanceSerializer
 from api.v2.views.base import AuthViewSet
 from api.v2.views.mixins import MultipleFieldLookup
+from core.exceptions import ProviderNotActive
 from core.models import Instance, Identity
 from core.models.boot_script import _save_scripts_to_instance
 from core.models.instance import find_instance
@@ -9,16 +10,22 @@ from core.query import only_current
 from rest_framework import status
 from rest_framework.decorators import detail_route
 from rest_framework.response import Response
-from service.instance import launch_instance, destroy_instance, run_instance_action, update_instance_metadata
+from service.instance import (
+    launch_instance, destroy_instance, run_instance_action,
+    update_instance_metadata)
 from threepio import logger
-
-#Things that go bump
-from api.v2.exceptions import failure_response, invalid_creds, connection_failure
-from api.exceptions import over_quota, under_threshold, size_not_available, over_capacity, mount_failed
+# Things that go bump
+from api.v2.exceptions import (
+    failure_response, invalid_creds, connection_failure)
+from api.exceptions import (
+    over_quota, under_threshold, size_not_available,
+    over_capacity, mount_failed, inactive_provider)
 from libcloud.common.types import InvalidCredsError
-from service.exceptions import ActionNotAllowed, OverAllocationError, OverQuotaError,\
-    SizeNotAvailable, HypervisorCapacityError, SecurityGroupNotCreated,\
-    UnderThresholdError, VolumeAttachConflict, VolumeMountConflict, InstanceDoesNotExist
+from service.exceptions import (
+    ActionNotAllowed, OverAllocationError, OverQuotaError,
+    SizeNotAvailable, HypervisorCapacityError, SecurityGroupNotCreated,
+    UnderThresholdError, VolumeAttachConflict, VolumeMountConflict,
+    InstanceDoesNotExist)
 from socket import error as socket_error
 from rtwo.exceptions import ConnectionFailure
 
@@ -97,6 +104,8 @@ class InstanceViewSet(MultipleFieldLookup, AuthViewSet):
             return invalid_creds(identity)
         except HypervisorCapacityError as hce:
             return over_capacity(hce)
+        except ProviderNotActive as pna:
+            return inactive_provider(pna)
         except (OverQuotaError, OverAllocationError) as oqe:
             return over_quota(oqe)
         except SizeNotAvailable as snae:
@@ -188,10 +197,10 @@ class InstanceViewSet(MultipleFieldLookup, AuthViewSet):
                 _save_scripts_to_instance(instance, boot_scripts)
         except UnderThresholdError as ute:
             return under_threshold(ute)
-        except OverQuotaError as oqe:
+        except (OverQuotaError, OverAllocationError) as oqe:
             return over_quota(oqe)
-        except OverAllocationError as oae:
-            return over_quota(oae)
+        except ProviderNotActive as pna:
+            return inactive_provider(pna)
         except SizeNotAvailable as snae:
             return size_not_available(snae)
         except HypervisorCapacityError as hce:

--- a/api/v2/views/volume.py
+++ b/api/v2/views/volume.py
@@ -7,10 +7,12 @@ from rest_framework.decorators import detail_route
 from rest_framework.response import Response
 from rest_framework import status
 
+from api.exceptions import (inactive_provider)
 from api.v2.serializers.details import VolumeSerializer, UpdateVolumeSerializer
 from api.v2.views.base import AuthViewSet
 from api.v2.views.mixins import MultipleFieldLookup
 
+from core.exceptions import ProviderNotActive
 from core.models.volume import Volume, find_volume
 from core.query import only_current_source
 from service.volume import create_volume_or_fail, destroy_volume_or_fail, update_volume_metadata
@@ -96,6 +98,8 @@ class VolumeViewSet(MultipleFieldLookup, AuthViewSet):
                             user=self.request.user)
         except InvalidCredsError as e:
             raise exceptions.PermissionDenied(detail=e.message)
+        except ProviderNotActive as pna:
+            return inactive_provider(pna)
         except VOLUME_EXCEPTIONS as e:
             raise exceptions.ParseError(detail=e.message)
 
@@ -106,5 +110,7 @@ class VolumeViewSet(MultipleFieldLookup, AuthViewSet):
             instance.save()
         except InvalidCredsError as e:
             raise exceptions.PermissionDenied(detail=e.message)
+        except ProviderNotActive as pna:
+            return inactive_provider(pna)
         except VOLUME_EXCEPTIONS as e:
             raise exceptions.ParseError(detail=e.message)

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -16,15 +16,24 @@ class SourceNotFound(Exception):
     """
     pass
 
+
 class RequestLimitExceeded(Exception):
     """
     A limit was exceeded for the specific request
     """
     pass
 
+
 class ProviderLimitExceeded(Exception):
 
     """
     A limit was exceeded for the specific provider
+    """
+    pass
+
+
+class ProviderNotActive(Exception):
+    """
+    The provider that was requested is not active
     """
     pass

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -36,4 +36,7 @@ class ProviderNotActive(Exception):
     """
     The provider that was requested is not active
     """
+    def __init__(self, provider, *args, **kwargs):
+        self.message = "Cannot create driver on an inactive provider:%s" \
+                       % (provider,)
     pass

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -37,6 +37,6 @@ class ProviderNotActive(Exception):
     The provider that was requested is not active
     """
     def __init__(self, provider, *args, **kwargs):
-        self.message = "Cannot create driver on an inactive provider:%s" \
-                       % (provider,)
+        self.message = "Cannot create driver on an inactive provider: %s" \
+                       % (provider.location,)
     pass

--- a/service/driver.py
+++ b/service/driver.py
@@ -163,9 +163,7 @@ def get_esh_driver(core_identity, username=None):
     try:
         core_provider = core_identity.provider
         if not core_provider.is_active():
-            raise ProviderNotActive(
-                "Cannot create driver on an inactive provider:%s" %
-                (core_identity.provider,))
+            raise ProviderNotActive(core_identity.provider)
         esh_map = get_esh_map(core_provider)
         if not username:
             user = core_identity.created_by

--- a/service/driver.py
+++ b/service/driver.py
@@ -7,6 +7,7 @@ from rtwo.identity import AWSIdentity, EucaIdentity,\
     OSIdentity
 from rtwo.driver import AWSDriver, EucaDriver, OSDriver
 
+from core.exceptions import ProviderNotActive
 from core.models import AtmosphereUser as User
 from core.models.identity import Identity as CoreIdentity
 from core.models.size import convert_esh_size
@@ -161,6 +162,10 @@ def get_esh_provider(core_provider, username=None):
 def get_esh_driver(core_identity, username=None):
     try:
         core_provider = core_identity.provider
+        if not core_provider.is_active():
+            raise ProviderNotActive(
+                "Cannot create driver on an inactive provider:%s" %
+                (core_identity.provider,))
         esh_map = get_esh_map(core_provider)
         if not username:
             user = core_identity.created_by
@@ -189,17 +194,13 @@ def prepare_driver(request, provider_uuid, identity_uuid,
     try:
         core_identity = CoreIdentity.objects.get(provider__uuid=provider_uuid,
                                                  uuid=identity_uuid)
-        if not core_identity.provider.is_active():
-            raise ValueError(
-                "Provider %s is NOT active. Driver not created." %
-                (core_identity.provider,))
         if core_identity in request.user.identity_set.all():
             return get_esh_driver(core_identity=core_identity)
         else:
-            raise Exception(
+            raise ValueError(
                 "User %s is NOT the owner of Identity UUID: %s" %
                 (request.user.username, core_identity.uuid))
-    except (CoreIdentity.DoesNotExist, ValueError, Exception):
+    except (CoreIdentity.DoesNotExist, ValueError):
         logger.exception("Unable to prepare driver.")
         if raise_exception:
             raise


### PR DESCRIPTION
[JIRA] (https://pods.iplantcollaborative.org/jira/browse/ATMO-782)

When a provider is marked inactive, let the user know via a non-200 API status code with a descriptive error message: `Cannot create driver on an inactive provider: iPlant Workshop Cloud - Tucson`

Providers are 'inactive'  when they have reached their `end_date` or when the `is_active` flag is toggled off.