### PR TITLE
End date resource requests

### DIFF
--- a/api/v2/serializers/details/resource_request.py
+++ b/api/v2/serializers/details/resource_request.py
@@ -195,9 +195,14 @@ class ResourceRequestSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class UserResourceRequestSerializer(serializers.HyperlinkedModelSerializer):
+    def validate_status(self, value):
+        if value not in ['pending', 'closed']:
+            raise serializers.ValidationError("Users can only open and close requests.")
+        return value
+
     quota = QuotaRelatedField(read_only=True)
     allocation = AllocationRelatedField(read_only=True)
-    status = StatusTypeRelatedField(read_only=True)
+    status = StatusTypeRelatedField(queryset = StatusType.objects.all(), default=StatusType.objects.get(name="pending"))
     admin_message = serializers.CharField(read_only=True)
     uuid = serializers.CharField(read_only=True)
     created_by = UserRelatedField(read_only=True)

--- a/api/v2/serializers/details/resource_request.py
+++ b/api/v2/serializers/details/resource_request.py
@@ -196,7 +196,7 @@ class ResourceRequestSerializer(serializers.HyperlinkedModelSerializer):
 
 class UserResourceRequestSerializer(serializers.HyperlinkedModelSerializer):
     def validate_status(self, value):
-        if value not in ['pending', 'closed']:
+        if str(value) not in ["pending", "closed"]:
             raise serializers.ValidationError("Users can only open and close requests.")
         return value
 

--- a/api/v2/views/base.py
+++ b/api/v2/views/base.py
@@ -178,7 +178,7 @@ class BaseRequestViewSet(MultipleFieldLookup, AuthViewSet):
                 if self.request._method == "PATCH":
                     instance = serializer.save(status=StatusType.objects.get(id=serializer.initial_data['status']))
                 else:
-                    instance = serializer.save(end_date=timezone.now())
+                    instance = serializer.save()
 
             if instance.is_approved():
                 self.approve_action(instance)

--- a/api/v2/views/base.py
+++ b/api/v2/views/base.py
@@ -175,10 +175,16 @@ class BaseRequestViewSet(MultipleFieldLookup, AuthViewSet):
                 instance = serializer.save(end_date=timezone.now(),
                                            membership=membership)
             else:
-                instance = serializer.save(end_date=timezone.now())
+                if self.request._method == "PATCH":
+                    instance = serializer.save(status=StatusType.objects.get(id=serializer.initial_data['status']))
+                else:
+                    instance = serializer.save(end_date=timezone.now())
 
             if instance.is_approved():
                 self.approve_action(instance)
+
+            if instance.is_closed():
+                self.close_action(instance)
 
             if instance.is_denied():
                 self.deny_action(instance)

--- a/api/v2/views/resource_request.py
+++ b/api/v2/views/resource_request.py
@@ -1,6 +1,8 @@
 from core.models import ResourceRequest
 from core import email
 
+from django.utils import timezone
+
 from api.v2.serializers.details import ResourceRequestSerializer,\
     UserResourceRequestSerializer
 from api.v2.views.base import BaseRequestViewSet
@@ -34,6 +36,8 @@ class ResourceRequestViewSet(BaseRequestViewSet):
         """
         Updates the resource for the request
         """
+        self.end_date = timezone.now()
+        self.save()
         membership = instance.membership
         membership.quota = instance.quota or membership.quota
         membership.allocation = instance.allocation or membership.allocation
@@ -54,6 +58,8 @@ class ResourceRequestViewSet(BaseRequestViewSet):
         """
         Notify the user that the request was denied
         """
+        self.end_date = timezone.now()
+        self.save()
         email.send_denied_resource_email(
             user=instance.created_by,
             request=instance.request,

--- a/api/v2/views/resource_request.py
+++ b/api/v2/views/resource_request.py
@@ -19,7 +19,14 @@ class ResourceRequestViewSet(BaseRequestViewSet):
     model = ResourceRequest
     serializer_class = UserResourceRequestSerializer
     admin_serializer_class = ResourceRequestSerializer
-    filter_fields = ('status__id', 'status__name')
+    filter_fields = ('status__id', 'status__name', 'created_by__username')
+
+    def close_action(self, instance):
+        """
+        Add an end date to a request and take no further action
+        """
+        self.end_date = timezone.now()
+        self.save()
 
     def submit_action(self, instance):
         """

--- a/core/models/abstract.py
+++ b/core/models/abstract.py
@@ -46,7 +46,7 @@ class BaseRequest(models.Model):
         """
         Only allow one active request per provider
         """
-        if not self.pk and self.is_active(self.membership):
+        if not self.pk and self.is_active(self.membership) and self.has_current_requests(self.membership):
             raise ProviderLimitExceeded(
                 "The number of open requests has been exceeded.")
 
@@ -55,6 +55,13 @@ class BaseRequest(models.Model):
                 "This membership does not belong to the user")
 
         super(BaseRequest, self).save(*args, **kwargs)
+
+    @classmethod
+    def has_current_requests(cls, identity_membership):
+        """
+        Return if the object currently has non end-dated objects
+        """
+        return cls.objects.filter(only_current()).count() > 0
 
     @classmethod
     def is_active(cls, identity_membership):


### PR DESCRIPTION
Allow users to close their own resource requests.

This is done by end dating resource requests when a PATCH is made to the resource_requests endpoint with a status of "closed." 

An end dated request also allows a user to make another request without their old request needing to be fully deleted from the database.