### PR TITLE
Allow CloudAdministrators to deactivate Atmosphere Users

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -44,9 +44,18 @@ class ProjectOwnerRequired(permissions.BasePermission):
 
 
 class ApiAuthRequired(permissions.BasePermission):
+    message = "The requested user could not be authenticated."
 
     def has_permission(self, request, view):
         return request.user.is_authenticated()
+
+
+class EnabledUserRequired(permissions.BasePermission):
+    message = "The account you are using has been disabled. "\
+        "Please contact your Cloud Administrator for more information."
+
+    def has_permission(self, request, view):
+        return request.user.is_enabled
 
 
 def _get_administrator_account(user, admin_uuid):

--- a/api/v1/views/profile.py
+++ b/api/v1/views/profile.py
@@ -4,8 +4,7 @@ Atmosphere service instance rest api.
 """
 from rest_framework.response import Response
 
-from core.models.profile import UserProfile
-
+from django.utils import timezone
 from api.v1.views.base import AuthAPIView
 from api.v1.serializers import ProfileSerializer, AtmoUserSerializer
 
@@ -24,9 +23,16 @@ class Profile(AuthAPIView):
         Authentication Required, retrieve the users profile.
         """
         user = request.user
+        # THIS IS A HACK! -- This check covered by permissions in v2
+        if not user.is_enabled:
+            return Response(
+                "The account <%s> has been disabled by an Administrator. "
+                "Please contact your Cloud Administrator for more information."
+                % (user.username,), status=403)  # Forbidden
+
         profile = user.userprofile
         serialized_data = ProfileSerializer(profile).data
-        identity = user.select_identity()
+        user.select_identity()
         response = Response(serialized_data)
         return response
 

--- a/api/v2/serializers/details/__init__.py
+++ b/api/v2/serializers/details/__init__.py
@@ -31,5 +31,5 @@ from .size import SizeSerializer
 from .status_type import StatusTypeSerializer
 from .tag import TagSerializer
 from .token import TokenSerializer
-from .user import UserSerializer
+from .user import AdminUserSerializer, UserSerializer
 from .volume import VolumeSerializer, UpdateVolumeSerializer

--- a/api/v2/serializers/details/identity_membership.py
+++ b/api/v2/serializers/details/identity_membership.py
@@ -9,6 +9,9 @@ from api.v2.serializers.summaries import (
 )
 
 class IdentityMembershipSerializer(serializers.HyperlinkedModelSerializer):
+    url = serializers.HyperlinkedIdentityField(
+        view_name='api:v2:identitymembership-detail',
+    )
     quota = QuotaSummarySerializer()
     allocation = AllocationSummarySerializer()
     identity = IdentitySummarySerializer()
@@ -18,7 +21,6 @@ class IdentityMembershipSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = IdentityMembership
-        view_name = 'api:v2:identity-detail' # TODO: Make an identity-membership-detail
         fields = ('id',
                   'url',
                   'quota',

--- a/api/v2/serializers/details/user.py
+++ b/api/v2/serializers/details/user.py
@@ -2,10 +2,12 @@ from core.models.user import AtmosphereUser
 from rest_framework import serializers
 from api.v2.serializers.fields.base import UUIDHyperlinkedIdentityField
 
+
 class UserSerializer(serializers.HyperlinkedModelSerializer):
     url = UUIDHyperlinkedIdentityField(
         view_name='api:v2:atmosphereuser-detail',
     )
+
     class Meta:
         model = AtmosphereUser
         fields = (
@@ -13,10 +15,26 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
             'uuid',
             'url',
             'username',
-            #'first_name',
-            #'last_name',
-            #'email',
-            #'is_staff',
-            #'is_superuser',
-            #'date_joined'
+            # 'first_name',
+            # 'last_name',
+            # 'email',
+            # 'is_staff',
+            # 'is_superuser',
+            # 'date_joined'
+        )
+
+
+class SimpleUpdateUserSerializer(UserSerializer):
+    url = UUIDHyperlinkedIdentityField(
+        view_name='api:v2:atmosphereuser-detail',
+    )
+
+    class Meta:
+        model = AtmosphereUser
+        fields = (
+            'id',
+            'uuid',
+            'url',
+            'username',
+            'end_date',
         )

--- a/api/v2/serializers/details/user.py
+++ b/api/v2/serializers/details/user.py
@@ -37,6 +37,7 @@ class AdminUserSerializer(serializers.HyperlinkedModelSerializer):
             'url',
             'username',
             'end_date',
+            'is_active',
             'is_staff',
             'is_superuser',
             'email',

--- a/api/v2/serializers/details/user.py
+++ b/api/v2/serializers/details/user.py
@@ -15,6 +15,7 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
             'uuid',
             'url',
             'username',
+            'end_date',
             # 'first_name',
             # 'last_name',
             # 'email',
@@ -23,8 +24,7 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
             # 'date_joined'
         )
 
-
-class SimpleUpdateUserSerializer(UserSerializer):
+class AdminUserSerializer(serializers.HyperlinkedModelSerializer):
     url = UUIDHyperlinkedIdentityField(
         view_name='api:v2:atmosphereuser-detail',
     )
@@ -37,4 +37,10 @@ class SimpleUpdateUserSerializer(UserSerializer):
             'url',
             'username',
             'end_date',
+            'is_staff',
+            'is_superuser',
+            'email',
+            # 'first_name',
+            # 'last_name',
+            # 'date_joined'
         )

--- a/api/v2/urls.py
+++ b/api/v2/urls.py
@@ -19,7 +19,7 @@ router.register(r'email_request_resources', views.ResourceEmailViewSet, base_nam
 router.register(r'emulate_token', views.TokenEmulateViewSet, base_name='emulate-token')
 router.register(r'emulate_session', views.SessionEmulateViewSet, base_name='emulate-session')
 router.register(r'identities', views.IdentityViewSet)
-router.register(r'identity_memberships', views.IdentityMembershipViewSet)
+router.register(r'identity_memberships', views.IdentityMembershipViewSet, base_name='identitymembership')
 router.register(r'images', views.ImageViewSet, base_name='application')
 router.register(r'image_bookmarks', views.ImageBookmarkViewSet)
 router.register(r'image_tags', views.ImageTagViewSet)

--- a/api/v2/views/base.py
+++ b/api/v2/views/base.py
@@ -11,7 +11,7 @@ from core.models import IdentityMembership
 from core.models.status_type import StatusType
 
 from api.permissions import (
-        ApiAuthOptional, ApiAuthRequired,
+        ApiAuthOptional, ApiAuthRequired, EnabledUserRequired,
         InMaintenance, CloudAdminRequired
     )
 from api.v2.views.mixins import MultipleFieldLookup
@@ -41,12 +41,14 @@ class AuthViewSet(ModelViewSet):
     http_method_names = ['get', 'put', 'patch', 'post',
                          'delete', 'head', 'options', 'trace']
     permission_classes = (InMaintenance,
+                          EnabledUserRequired,
                           ApiAuthRequired,)
 
 
 class AdminAuthViewSet(AuthViewSet):
     permission_classes = (InMaintenance,
                           CloudAdminRequired,
+                          EnabledUserRequired,
                           ApiAuthRequired,)
 
 

--- a/api/v2/views/user.py
+++ b/api/v2/views/user.py
@@ -1,7 +1,7 @@
 from core.models import AtmosphereUser
 from api.permissions import ApiAuthRequired, CloudAdminRequired,\
     InMaintenance
-from api.v2.serializers.details import UserSerializer
+from api.v2.serializers.details import UserSerializer, AdminUserSerializer
 from api.v2.views.base import AdminAuthViewSet
 from api.v2.views.mixins import MultipleFieldLookup
 
@@ -55,8 +55,9 @@ class UserViewSet(MultipleFieldLookup, AdminAuthViewSet):
     search_fields = ('^username',)  # NOTE: ^ == Startswith searching
 
     def get_serializer_class(self):
-        if self.request.method in UPDATE_METHODS:
-            return SimpleUpdateUserSerializer
+        if self.request.method in UPDATE_METHODS or \
+                (self.request.user.is_staff or self.request.user.is_superuser):
+            return AdminUserSerializer
         return self.serializer_class
 
     def get_permissions(self):

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -26,6 +26,18 @@ class AtmosphereUser(AbstractUser):
         return identity_member.quota
 
     @property
+    def is_enabled(self):
+        """
+        User is enabled if:
+        1. They do not have an end_date
+        _OR_ They have an end_date that is not past the current time
+        2. The 'is_active' flag is True
+        """
+        now_time = timezone.now()
+        return self.is_active and \
+            (not self.end_date or self.end_date > now_time)
+
+    @property
     def current_identities(self):
         from core.models import Identity
         all_identities = Identity.objects.none()


### PR DESCRIPTION
Give CloudAdministrators the ability to set 'is_staff', 'is_superuser', and activate/deactivate a user (By setting an end_date && marking 'is_active') on troposphere.

Users who login to troposphere after being deactivated will receive a banner message with related error message upon arriving at the 'Forbidden//No User' page.

[JIRA] (https://pods.iplantcollaborative.org/jira/browse/ATMO-979)
[Atmosphere PR] (https://github.com/iPlantCollaborativeOpenSource/atmosphere/pull/77)
[Troposphere PR] (https://github.com/iPlantCollaborativeOpenSource/troposphere/pull/221)
