### PR TITLE
fix typo in exempt allocation list

### DIFF
--- a/service/tasks/monitoring.py
+++ b/service/tasks/monitoring.py
@@ -551,7 +551,7 @@ def monthly_allocation_reset():
 def reset_provider_allocation(provider_id, default_allocation_id):
     provider = Provider.objects.get(id=provider_id)
     default_allocation = Allocation.objects.get(id=default_allocation_id)
-    exempt_allocation_list = Allocation.objects.filter(threshold=-1)
+    exempt_allocation_list = Allocation.objects.filter(delta=-1)
     users_reset = 0
     memberships_reset = []
     for ident in provider.identity_set.all():


### PR DESCRIPTION
The exempt allocation list incorrectly contained allocations with threshold of -1, which was an empty list. This has been corrected to delta = -1, which will fix monthly allocation reset happening for users who should be exempt.