### PR TITLE
Added the hyperlink relation to the detail view for identity membership.

### DIFF
--- a/api/v2/serializers/details/identity_membership.py
+++ b/api/v2/serializers/details/identity_membership.py
@@ -14,11 +14,12 @@ class IdentityMembershipSerializer(serializers.HyperlinkedModelSerializer):
     identity = IdentitySummarySerializer()
     user = UserSummarySerializer(source='identity.created_by')
     provider = ProviderSummarySerializer(source='identity.provider')
-
+    url = serializers.HyperlinkedIdentityField(
+        view_name='api:v2:identitymembership-detail',
+    )
 
     class Meta:
         model = IdentityMembership
-        view_name = 'api:v2:identity-detail' # TODO: Make an identity-membership-detail
         fields = ('id',
                   'url',
                   'quota',


### PR DESCRIPTION
This is the intended fix that #82 was missing.  See #82. 