### PR TITLE
Fix response error encountered when attaching volumes. 

### DIFF
--- a/api/v1/views/instance.py
+++ b/api/v1/views/instance.py
@@ -227,6 +227,18 @@ def _filter_instance_history(history_instance_list, params):
     return history_instance_list
 
 
+def _further_process(request, action, result):
+    """
+    Provide additional serialization if the `action` has a
+    `result` requiring processing.
+    """
+    if 'volume' in action:
+        return VolumeSerializer(result,
+                                context={"request": request}).data
+    else:
+        return result
+
+
 class InstanceHistory(AuthListAPIView):
 
     """Instance history for a specific user."""
@@ -434,6 +446,7 @@ class InstanceAction(AuthAPIView):
         action = action_params['action']
         try:
             result_obj = run_instance_action(user, identity, instance_id, action, action_params)
+            result_obj = _further_process(request, action, result_obj)
             api_response = {
                 'result': 'success',
                 'message': 'The requested action <%s> was run successfully' % (action_params['action'],),

--- a/api/v1/views/instance.py
+++ b/api/v1/views/instance.py
@@ -227,18 +227,6 @@ def _filter_instance_history(history_instance_list, params):
     return history_instance_list
 
 
-def _further_process_result(request, action, result):
-    """
-    Provide additional serialization if the `action` has a
-    `result` requiring processing.
-    """
-    if 'volume' in action:
-        return VolumeSerializer(result,
-                                context={"request": request}).data
-    else:
-        return result
-
-
 class InstanceHistory(AuthListAPIView):
 
     """Instance history for a specific user."""
@@ -361,6 +349,20 @@ class InstanceStatusHistoryDetail(AuthAPIView):
         response = Response(serialized_data)
         response['Cache-Control'] = 'no-cache'
         return response
+
+
+
+
+def _further_process_result(request, action, result):
+    """
+    Provide additional serialization if the `action` has a
+    `result` requiring processing.
+    """
+    if 'volume' in action:
+        return VolumeSerializer(result,
+                                context={"request": request}).data
+    else:
+        return result
 
 
 class InstanceAction(AuthAPIView):

--- a/api/v1/views/instance.py
+++ b/api/v1/views/instance.py
@@ -227,7 +227,7 @@ def _filter_instance_history(history_instance_list, params):
     return history_instance_list
 
 
-def _further_process(request, action, result):
+def _further_process_result(request, action, result):
     """
     Provide additional serialization if the `action` has a
     `result` requiring processing.
@@ -446,7 +446,7 @@ class InstanceAction(AuthAPIView):
         action = action_params['action']
         try:
             result_obj = run_instance_action(user, identity, instance_id, action, action_params)
-            result_obj = _further_process(request, action, result_obj)
+            result_obj = _further_process_result(request, action, result_obj)
             api_response = {
                 'result': 'success',
                 'message': 'The requested action <%s> was run successfully' % (action_params['action'],),


### PR DESCRIPTION
When attaching to detach or attach (so, _instance actions_ associated with volumes), there is an error produced in the endpoint's response: 
![screen shot 2015-12-15 at 2 40 44 pm](https://cloud.githubusercontent.com/assets/5923/11881490/592d1fdc-a4c4-11e5-83d3-4f4576daced5.png)

At the heart of the error is that the object passed into the serializer is _actually_ a string presentation of a `Volume` model - and not valid JSON: 
```
... <Volume: 348b58a4-266b-4f01-93f8-91e437b588af> is not JSON serializable
```

It turns out that in refactoring the endpoints for the completion of work on _v2_, the following code from [](https://github.com/iPlantCollaborativeOpenSource/atmosphere/blob/incana-incana/api/v1/views/instance.py#L501-L508) got shift around. 

So in [`incana-incana`](https://github.com/iPlantCollaborativeOpenSource/atmosphere/blob/incana-incana/api/v1/views/instance.py#L501-L508), we handled _actions_ associated to volumes like so:
```python
                esh_volume = esh_driver.get_volume(volume_id)
                core_volume = convert_esh_volume(esh_volume,
                                                 provider_uuid,
                                                 identity_uuid,
                                                 user)
                result_obj =\
                    VolumeSerializer(core_volume,
                                     context={"request": request}).data
```

However, we needed to generalize this - and moved the common part over to [`/service/instance.py`](https://github.com/iPlantCollaborativeOpenSource/atmosphere/blob/master/service/instance.py#L1573-L1653). And the handling of volumes was being done within celery task code, so serialization there makes no sense. The appropriate code for [volumes](https://github.com/iPlantCollaborativeOpenSource/atmosphere/blob/master/service/instance.py#L1566-L1571) does the necessary calls to the `esh_driver` and returns the `core_volume`: 
```python 
    esh_volume = esh_driver.get_volume(volume_id)
    core_volume = convert_esh_volume(esh_volume,
                                     provider_uuid,
                                     identity_uuid,
                                     user)
    return core_volume
```

So when handling the [`POST`](https://github.com/iPlantCollaborativeOpenSource/atmosphere/blob/master/api/v1/views/instance.py#L436-L442), we will get a `result` object that _could_ need additional, conditional serializer - or can be simply passed along in the `api_response`: 
```python
            result_obj = run_instance_action(user, identity, instance_id, action, action_params)
            api_response = {
                'result': 'success',
                'message': 'The requested action <%s> was run successfully' % (action_params['action'],),
                'object': result_obj,
            }
            response = Response(api_response, status=status.HTTP_200_OK)
            return response
```

But, when dealing with an action on volumes - we still need to use `VolumeSerializer`. 

This pull request fixes the serialization error and introduces a function used by `InstanceAction` to conditionally apply further processing to a result:
```python
def _further_process_result(request, action, result):
    """
    Provide additional serialization if the `action` has a
    `result` requiring processing.
    """
    if 'volume' in action:
        return VolumeSerializer(result,
                                context={"request": request}).data
    else:
        return result
```
