### PR TITLE
Fix - Removed `old_status` initial value from machine_request view.

### DIFF
--- a/api/v2/views/machine_request.py
+++ b/api/v2/views/machine_request.py
@@ -65,7 +65,6 @@ class MachineRequestViewSet(BaseRequestViewSet):
             instance = serializer.save(
                 membership=membership,
                 status=status,
-                old_status="processing",
                 created_by=self.request.user,
                 new_machine_provider = new_machine_provider,
                 new_machine_owner = new_machine_owner,


### PR DESCRIPTION
Setting `old_status` to `"processing"` in the machine_request view was causing issues with the handling of Image Requests ([ATMO-1104](https://pods.iplantcollaborative.org/jira/browse/ATMO-1104)). By removing this initial value for `old_status`, the value is set based on the default (depending on if the deployment is _auto-imaging_ or not). 

See [ATMO-1104](https://pods.iplantcollaborative.org/jira/browse/ATMO-1104) for more details. 