### PR TITLE
Raise v1 machine exception

### DIFF
--- a/api/v1/views/machine.py
+++ b/api/v1/views/machine.py
@@ -53,8 +53,7 @@ def provider_filtered_machines(request, provider_uuid,
         esh_driver = None
 
     if not esh_driver:
-        return invalid_creds(provider_uuid, identity_uuid)
-
+        raise InvalidCredsError()
     logger.debug(esh_driver)
 
     return list_filtered_machines(esh_driver, provider_uuid, request_user)


### PR DESCRIPTION
Addresses ATMO-976
Return invalid_provider_identity when an identity doesn't exist on a provider. Previously returned an HTML response to a serializer that caused DRF issue.