### PR TITLE
Fix API v2 /volume POST and DELETE methods

### DIFF
--- a/api/v2/serializers/details/volume.py
+++ b/api/v2/serializers/details/volume.py
@@ -82,7 +82,7 @@ class VolumeSerializer(serializers.HyperlinkedModelSerializer):
 
         instance_source = validated_data.get("instance_source")
         identity = instance_source.get("created_by_identity")
-        provider = instance_source.get('provider')
+        provider = identity.provider
 
         source = InstanceSource.objects.create(
             identifier=identifier,

--- a/api/v2/views/volume.py
+++ b/api/v2/views/volume.py
@@ -86,7 +86,6 @@ class VolumeViewSet(MultipleFieldLookup, AuthViewSet):
         instance_source = data.get("instance_source")
         identity = instance_source.get("created_by_identity")
         provider = identity.provider
-
         try:
             esh_volume = create_volume_or_fail(name, size, self.request.user,
                                                provider, identity,

--- a/api/v2/views/volume.py
+++ b/api/v2/views/volume.py
@@ -104,7 +104,8 @@ class VolumeViewSet(MultipleFieldLookup, AuthViewSet):
         except VOLUME_EXCEPTIONS as e:
             raise exceptions.ParseError(detail=e.message)
         except Exception as exc:
-            logger.exception("Error occurred creating a v2 volume")
+            logger.exception("Error occurred creating a v2 volume -- User:%s"
+                             % self.request.user)
             return Response(exc.message, status=status.HTTP_409_CONFLICT)
 
     def perform_destroy(self, instance):
@@ -118,3 +119,7 @@ class VolumeViewSet(MultipleFieldLookup, AuthViewSet):
             return inactive_provider(pna)
         except VOLUME_EXCEPTIONS as e:
             raise exceptions.ParseError(detail=e.message)
+        except Exception as exc:
+            logger.exception("Error occurred deleting a v2 volume -- User:%s"
+                             % self.request.user)
+            return Response(exc.message, status=status.HTTP_409_CONFLICT)

--- a/api/v2/views/volume.py
+++ b/api/v2/views/volume.py
@@ -80,8 +80,8 @@ class VolumeViewSet(MultipleFieldLookup, AuthViewSet):
         data = serializer.validated_data
         name = data.get('name')
         size = data.get('size')
-        image_id = data.get('image')
-        snapshot_id = data.get('snapshot')
+        image_id = data.get('image_id')
+        snapshot_id = data.get('snapshot_id')
         description = data.get('description')
         instance_source = data.get("instance_source")
         identity = instance_source.get("created_by_identity")
@@ -103,6 +103,9 @@ class VolumeViewSet(MultipleFieldLookup, AuthViewSet):
             return inactive_provider(pna)
         except VOLUME_EXCEPTIONS as e:
             raise exceptions.ParseError(detail=e.message)
+        except Exception as exc:
+            logger.exception("Error occurred creating a v2 volume")
+            return Response(exc.message, status=status.HTTP_409_CONFLICT)
 
     def perform_destroy(self, instance):
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ uWSGI==2.0.9
 ## ours
 django-iplant-auth==0.1.2
 threepio==0.2.0
-rtwo==0.2.17
+rtwo==0.2.18
 caslib.py==2.2.2
 chromogenic==0.1.8
 subspace==0.1.6

--- a/service/volume.py
+++ b/service/volume.py
@@ -53,11 +53,12 @@ def _update_volume_metadata(esh_driver, esh_volume,
 
 
 def restrict_size_by_image(size, image):
-    image_size = image._connection.get_size(image._image)
+    image_bytes = image._image.extra['image_size']
+    image_size = int(image_bytes / 1024.0**3)
     if size > image_size + 4:
         raise exceptions.VolumeError(
             "Volumes created from images cannot exceed "
-            "more than 4GB greater than the size of the image:%s GB"
+            "more than 4GB greater than the size of the image:(%s GB)"
             % size)
 
 

--- a/service/volume.py
+++ b/service/volume.py
@@ -53,7 +53,12 @@ def _update_volume_metadata(esh_driver, esh_volume,
 
 
 def restrict_size_by_image(size, image):
-    image_bytes = image._image.extra['image_size']
+    image_bytes = image._image.extra.get('image_size', None)
+    if not image_bytes:
+        raise exceptions.VolumeError(
+            "Cannot determine size of the image %s: "
+            "Expected rtwo.machine.OSMachine to include "
+            "'image_size' key in the 'extra' fields." % (image.name,))
     image_size = int(image_bytes / 1024.0**3)
     if size > image_size + 4:
         raise exceptions.VolumeError(


### PR DESCRIPTION
The perform_create and perform_delete methods, previously, were pointing to bad functions and variable names. As well, some variables were being requested that were not necessary for CREATE. All of these errors have been fixed. Description is now a passable kwarg when POSTing to volume.

An update to rtwo (0.2.18) was required to move forward.

I did test creating volumes with image_id and was unable to perform the action on OpenStack Havana. We can revisit why Images aren't being copied into Volumes when we are running a later version of OStack.