### PR TITLE
Fix periodic task 'prune_machines'

### DIFF
--- a/core/models/application.py
+++ b/core/models/application.py
@@ -39,6 +39,12 @@ class Application(models.Model):
     created_by_identity = models.ForeignKey(Identity, null=True)
 
     @property
+    def all_versions(self):
+        version_set = ApplicationVersion.objects.filter(
+            application=self)
+        return version_set
+
+    @property
     def all_machines(self):
         from core.models import ProviderMachine
         providermachine_set = ProviderMachine.objects.filter(

--- a/core/models/application.py
+++ b/core/models/application.py
@@ -129,6 +129,17 @@ class Application(models.Model):
                 shared_images | admin_images).distinct()
         return all_the_images
 
+    def _current_versions(self):
+        """
+        Return a list of current application versions.
+        NOTE: Defined as:
+                * The ApplicationVersion has not exceeded its end_date
+        """
+        version_set = self.all_versions
+        active_versions = version_set.filter(
+            only_current())
+        return active_versions
+
     def _current_machines(self, request_user=None):
         """
         Return a list of current provider machines.

--- a/core/models/application.py
+++ b/core/models/application.py
@@ -61,13 +61,7 @@ class Application(models.Model):
         if not now:
             now = timezone.now()
         for version in self.versions.all():
-            for machine in version.machines.all():
-                if not machine.end_date:
-                    machine.end_date = now
-                    machine.save()
-            if not version.end_date:
-                version.end_date = now
-                version.save()
+            version.end_date_all(now)
         if not self.end_date:
             self.end_date = now
             self.save()

--- a/core/models/application_version.py
+++ b/core/models/application_version.py
@@ -73,6 +73,17 @@ class ApplicationVersion(models.Model):
                                self.name,
                                self.start_date)
 
+    def end_date_all(self, now=None):
+        if not now:
+            now = timezone.now()
+        for machine in self.machines.all():
+            if not machine.end_date:
+                machine.end_date = now
+                machine.save()
+        if not self.end_date:
+            self.end_date = now
+            self.save()
+
     def active_machines(self):
         """
         Show machines that are from an active provider and non-end-dated.

--- a/core/query.py
+++ b/core/query.py
@@ -2,6 +2,18 @@ from django.db.models import Q
 from django.utils import timezone
 
 
+def inactive_versions():
+    return (
+        # Contains at least one version without an end-date OR
+        (Q(num_versions__gt=0) & Q(versions__end_date__isnull=True)) |
+        # conatins at least one machine without an end-date
+        (
+            Q(num_machines__gt=0) &
+            Q(versions__machines__instance_source__end_date__isnull=True)
+        )
+    )
+
+
 def only_active_provider():
     """
     Use this query on any model with a 'provider.active'


### PR DESCRIPTION
Fix for ATMO-1114

Fixed prune machines so that it will prune invalid Apps, Versions and ProviderMachines based on cloud *and* database values.

Added some convenience methods for `end_date_all()` and `_current_versions()`