### PR TITLE
Update image version

### DIFF
--- a/api/v2/serializers/details/image_version.py
+++ b/api/v2/serializers/details/image_version.py
@@ -103,7 +103,7 @@ class ImageVersionSerializer(serializers.HyperlinkedModelSerializer):
         except:
             new_cpu_min = current_cpu_min
 
-        if not instance.get_threshold():
+        if not current_threshold:
             new_threshold = ApplicationThreshold.objects.create(
                 application_version=instance,
                 memory_min=new_mem_min,
@@ -114,4 +114,4 @@ class ImageVersionSerializer(serializers.HyperlinkedModelSerializer):
             new_threshold.cpu_min = new_cpu_min
             new_threshold.save()
 
-        instance.threshold = new_threshold
+        validated_data['threshold'] = new_threshold

--- a/api/v2/serializers/details/image_version.py
+++ b/api/v2/serializers/details/image_version.py
@@ -1,6 +1,6 @@
 from core.models import ApplicationVersion as ImageVersion
 from core.models import Application as Image
-from core.models import License, BootScript
+from core.models import License, BootScript, ProviderMachine, ApplicationThreshold
 from rest_framework import serializers
 from api.v2.serializers.summaries import (
     BootScriptSummarySerializer,
@@ -8,7 +8,8 @@ from api.v2.serializers.summaries import (
     UserSummarySerializer,
     ImageSummarySerializer,
     IdentitySummarySerializer,
-    ImageVersionSummarySerializer)
+    ImageVersionSummarySerializer,
+    ProviderMachineSummarySerializer)
 from api.v2.serializers.fields import (
     ProviderMachineRelatedField, ModelRelatedField)
 from api.v2.serializers.fields.base import UUIDHyperlinkedIdentityField
@@ -37,15 +38,17 @@ class ImageVersionSerializer(serializers.HyperlinkedModelSerializer):
         many=True)  # NEW
     user = UserSummarySerializer(source='created_by')
     identity = IdentitySummarySerializer(source='created_by_identity')
-    machines = ProviderMachineRelatedField(many=True)
+    machines = ModelRelatedField(many=True, queryset=ProviderMachine.objects.all(),
+        serializer_class=ProviderMachineSummarySerializer,
+        style={'base_template': 'input.html'})
     image = ModelRelatedField(
         source='application',
         queryset=Image.objects.all(),
         serializer_class=ImageSummarySerializer,
         style={'base_template': 'input.html'})
     start_date = serializers.DateTimeField()
-    min_mem = serializers.CharField(source='threshold.memory_min', read_only = True)
-    min_cpu = serializers.CharField(source='threshold.cpu_min', read_only = True)
+    min_mem = serializers.IntegerField(source='threshold.memory_min')
+    min_cpu = serializers.IntegerField(source='threshold.cpu_min')
     end_date = serializers.DateTimeField(allow_null=True)
     url = UUIDHyperlinkedIdentityField(
         view_name='api:v2:imageversion-detail',
@@ -58,3 +61,24 @@ class ImageVersionSerializer(serializers.HyperlinkedModelSerializer):
                   'licenses', 'membership', 'min_mem', 'min_cpu', 'scripts',
                   'user', 'identity',
                   'start_date', 'end_date')
+
+    def update(self, instance, validated_data):
+        current_threshold = instance.application.get_threshold()
+        current_mem_min = current_threshold.memory_min
+        current_cpu_min = current_threshold.cpu_min
+
+        try:
+            new_mem_min = validated_data.get('threshold')['memory_min']
+        except:
+            new_mem_min = current_mem_min
+
+        try:
+            new_cpu_min = validated_data.get('threshold')['cpu_min']
+        except:
+            new_cpu_min = current_cpu_min
+
+        # get item at 0 to retireve the item itself, we don't care if it was created
+        new_threshold = ApplicationThreshold.objects.get_or_create(memory_min=new_mem_min, cpu_min=new_cpu_min)[0]
+        instance.threshold = new_threshold
+        instance.save()
+        return instance

--- a/api/v2/serializers/details/image_version.py
+++ b/api/v2/serializers/details/image_version.py
@@ -64,8 +64,16 @@ class ImageVersionSerializer(serializers.HyperlinkedModelSerializer):
 
     def update(self, instance, validated_data):
         current_threshold = instance.application.get_threshold()
-        current_mem_min = current_threshold.memory_min
-        current_cpu_min = current_threshold.cpu_min
+
+        try:
+            current_mem_min = current_threshold.memory_min
+        except:
+            current_mem_min = None
+
+        try:
+            current_cpu_min = current_threshold.cpu_min
+        except:
+            current_cpu_min = None
 
         try:
             new_mem_min = validated_data.get('threshold')['memory_min']

--- a/core/models/application.py
+++ b/core/models/application.py
@@ -166,12 +166,6 @@ class Application(models.Model):
             ).order_by('instance_source__start_date').last()
         return last
 
-    def get_threshold(self):
-        try:
-            return self.latest_version.threshold
-        except ApplicationThreshold.DoesNotExist:
-            return None
-
     def get_projects(self, user):
         projects = self.projects.filter(
             only_current(),

--- a/core/models/application_version.py
+++ b/core/models/application_version.py
@@ -74,6 +74,7 @@ class ApplicationVersion(models.Model):
                                self.start_date)
 
     def get_threshold(self):
+        from core.models.application import ApplicationThreshold
         try:
             return self.threshold
         except ApplicationThreshold.DoesNotExist:

--- a/core/models/application_version.py
+++ b/core/models/application_version.py
@@ -73,6 +73,12 @@ class ApplicationVersion(models.Model):
                                self.name,
                                self.start_date)
 
+    def get_threshold(self):
+        try:
+            return self.threshold
+        except ApplicationThreshold.DoesNotExist:
+            return None
+
     def active_machines(self):
         """
         Show machines that are from an active provider and non-end-dated.

--- a/service/instance.py
+++ b/service/instance.py
@@ -1188,8 +1188,11 @@ def check_application_threshold(
     application = Application.objects.filter(
         versions__machines__instance_source__identifier=boot_source.identifier,
         versions__machines__instance_source__provider=core_identity.provider).distinct().get()
-    threshold = application.latest_version.get_threshold()
-#TODO: This is *NOT* good logic. Instead, look at 'boot_source' and determine what ApplicationVersion (If any) it belongs to. THEN use that version to 'get_threshold().
+    try:
+        threshold = boot_source.current_source.application_version.get_threshold()
+    except:
+        threshold = application.latest_version.get_threshold()
+
     if not threshold:
         return
     # NOTE: Should be MB to MB test

--- a/service/instance.py
+++ b/service/instance.py
@@ -1191,10 +1191,11 @@ def check_application_threshold(
     try:
         threshold = boot_source.current_source.application_version.get_threshold()
     except:
-        threshold = application.latest_version.get_threshold()
+        return
 
     if not threshold:
         return
+    
     # NOTE: Should be MB to MB test
     if esh_size.ram < threshold.memory_min:
         raise UnderThresholdError("This application requires >=%s GB of RAM."

--- a/service/instance.py
+++ b/service/instance.py
@@ -1188,7 +1188,8 @@ def check_application_threshold(
     application = Application.objects.filter(
         versions__machines__instance_source__identifier=boot_source.identifier,
         versions__machines__instance_source__provider=core_identity.provider).distinct().get()
-    threshold = application.get_threshold()
+    threshold = application.latest_version.get_threshold()
+#TODO: This is *NOT* good logic. Instead, look at 'boot_source' and determine what ApplicationVersion (If any) it belongs to. THEN use that version to 'get_threshold().
     if not threshold:
         return
     # NOTE: Should be MB to MB test


### PR DESCRIPTION
Addresses ATMO-1138

Allow users to update minimum requirements of the images they own.
Users can update either min_cpu or min_mem or both, and both will default to 0 if no value is given.
CPU is currently limited to positive integers less than 16, and memory is limited to positive integers less than 32 * 1024 (32 GB).

##### Troposphere PR #256 is dependent on this PR