### PR TITLE
Fix instance deleted

### DIFF
--- a/api/v1/views/instance.py
+++ b/api/v1/views/instance.py
@@ -699,7 +699,6 @@ class Instance(AuthAPIView):
                                     str(exc.message))
         try:
             # Test that there is not an attached volume BEFORE we destroy
-
             task.destroy_instance_task(user, esh_instance, identity_uuid)
 
             invalidate_cached_instances(
@@ -719,6 +718,10 @@ class Instance(AuthAPIView):
             return connection_failure(provider_uuid, identity_uuid)
         except InvalidCredsError:
             return invalid_creds(provider_uuid, identity_uuid)
+        except InstanceDoesNotExist as dne:
+            return failure_response(
+                status.HTTP_404_NOT_FOUND,
+                'Instance %s no longer exists' % (dne.message,))
         except Exception as exc:
             logger.exception("Encountered a generic exception. "
                              "Returning 409-CONFLICT")

--- a/service/exceptions.py
+++ b/service/exceptions.py
@@ -30,15 +30,7 @@ class InstanceDoesNotExist(ServiceException):
     def __init__(self, instance_id):
         self.message = instance_id
         self.status_code = 404
-        super(UnderThresholdError, self).__init__()
-
-
-class InstanceDoesNotExist(ServiceException):
-
-    def __init__(self, instance_id):
-        self.message = instance_id
-        self.status_code = 404
-        super(UnderThresholdError, self).__init__()
+        super(InstanceDoesNotExist, self).__init__()
 
 
 class UnderThresholdError(ServiceException):

--- a/service/task.py
+++ b/service/task.py
@@ -8,7 +8,7 @@ from threepio import logger
 
 import service
 
-from service.exceptions import DeviceBusyException, VolumeMountConflict
+from service.exceptions import DeviceBusyException, VolumeMountConflict, InstanceDoesNotExist
 
 from service.tasks.driver import deploy_to, deploy_init_to, add_floating_ip
 from service.tasks.driver import destroy_instance
@@ -64,6 +64,8 @@ def add_floating_ip_task(driver, instance, *args, **kwargs):
 
 
 def destroy_instance_task(user, instance, identity_uuid, *args, **kwargs):
+    if not instance:
+        raise InstanceDoesNotExist(instance_id=identity_uuid)
     return destroy_instance.delay(
         instance.alias, user, identity_uuid, *args, **kwargs)
 


### PR DESCRIPTION
Addresses ATMO-1141
When attempting to delete an instance that no longer exists, raise 404 error with descriptive error. 

Previously, there were checks in all instance actions **except** the delete action to see if the instance exists before continuing.

This PR adds that check before deleting an instance, and fixes an error in the exception that was being raised in all other actions in the case of a nonexistent instance. 

Here is a timeline of the original error returned by the API when deleting a nonexistent instance to the current error being returned.
![errors](https://cloud.githubusercontent.com/assets/11079642/12652312/7984db68-c5a7-11e5-8c7e-3d963f1f93f4.png)
