### PR TITLE
Update user boot scripts deployment to include injection of $ATMO_ variables

### DIFF
--- a/core/models/boot_script.py
+++ b/core/models/boot_script.py
@@ -61,8 +61,8 @@ class BootScript(models.Model):
         return slugify(self.title).replace('-', '_')
 
     def get_text(self):
-        if self.script_type.name == 'Full Text':
-            return self.script_text
+        if self.script_type.name == 'Raw Text':
+            return self.script_text.strip ()  # Remove whitespace
         elif self.script_type.name == 'URL':
             return self._text_from_url()
 

--- a/core/models/boot_script.py
+++ b/core/models/boot_script.py
@@ -62,7 +62,7 @@ class BootScript(models.Model):
 
     def get_text(self):
         if self.script_type.name == 'Raw Text':
-            return self.script_text.strip ()  # Remove whitespace
+            return self.script_text.strip()  # Remove whitespace
         elif self.script_type.name == 'URL':
             return self._text_from_url()
 

--- a/core/templates/scripts/bash_inject_env.sh
+++ b/core/templates/scripts/bash_inject_env.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+atmo_user="{{ username }}"
+env_file="{{ env_file }}"
+env_vars=`cat $env_file`
+if [[ $env_vars == *"ATMO_USER="* ]]; then
+    sed -i "s/ATMO_USER=.*/ATMO_USER=\"$atmo_user\"/" $env_file
+else
+    echo "ATMO_USER=\"$atmo_user\"" >> $env_file
+fi

--- a/service/deploy.py
+++ b/service/deploy.py
@@ -6,6 +6,7 @@ import os
 import sys
 import time
 
+from django.utils.text import slugify
 from django.utils.timezone import datetime
 
 from libcloud.compute.deployment import Deployment, ScriptDeployment,\
@@ -464,9 +465,27 @@ def wrap_script(script_text, script_name):
     * Chmod the file
     * Execute and redirect output to stdout/stderr to logfile.
     """
-    logfile = "/var/log/atmo/post_boot_scripts.log"
+    # logfile = "/var/log/atmo/post_boot_scripts.log"
     # kludge: weirdness without the str cast...
     script_text = str(script_text)
-    full_script_name = "./deploy_boot_script_%s.sh"
+    full_script_name = "./deploy_boot_script_%s.sh" % (slugify(script_name),)
     return ScriptDeployment(
         script_text, name=full_script_name)
+
+
+def _inject_env_script(username):
+    """
+    This is the 'raw script' that will be used to prepare the environment.
+    TODO: Find a better home for this. Probably use ansible for this.
+    """
+    return \
+        """#!/bin/bash -x
+atmo_user="%s"
+env_file="%s"
+env_vars=`cat $env_file`
+if [[ $env_vars == *"ATMO_USER="* ]]; then
+    sed -i "s/ATMO_USER=.*/ATMO_USER=\"$atmo_user\"/" $env_file
+else
+    echo "ATMO_USER=\"$atmo_user\"" >> $env_file
+fi
+""" % (username, "$HOME/.bashrc")

--- a/service/instance.py
+++ b/service/instance.py
@@ -93,7 +93,8 @@ def reboot_instance(
     check_quota(user.username, identity_uuid, None, resuming=True)
     esh_driver.reboot_instance(esh_instance, reboot_type=reboot_type)
     # reboots take very little time..
-    redeploy_init(esh_driver, esh_instance)
+    core_identity = CoreIdentity.objects.get(uuid=identity_uuid)
+    redeploy_init(esh_driver, esh_instance, core_identity)
 
 
 def resize_instance(esh_driver, esh_instance, size_alias,
@@ -357,8 +358,7 @@ def resize_and_redeploy(esh_driver, esh_instance, core_identity_uuid):
         core_identity.provider.id, core_identity.id, core_identity.created_by)
     task_four = deploy_init_to.si(
         esh_driver.__class__, esh_driver.provider,
-        esh_driver.identity, esh_instance.id,
-        redeploy=True)
+        esh_driver.identity, esh_instance.id, core_identity, redeploy=True)
     # Link em all together!
     task_one.link(task_two)
     task_two.link(task_three)
@@ -389,7 +389,7 @@ def redeploy_instance(
     return deploy_chain.apply_async()
 
 
-def redeploy_init(esh_driver, esh_instance):
+def redeploy_init(esh_driver, esh_instance, core_identity):
     """
     Use this function to kick off the async task when you ONLY want to deploy
     (No add fixed, No add floating)
@@ -398,7 +398,7 @@ def redeploy_init(esh_driver, esh_instance):
     logger.info("Add floating IP and Deploy")
     deploy_init_to.s(esh_driver.__class__, esh_driver.provider,
                      esh_driver.identity, esh_instance.id,
-                     redeploy=True).apply_async()
+                     core_identity, redeploy=True).apply_async()
 
 
 def restore_ip_chain(esh_driver, esh_instance, redeploy=False,
@@ -423,11 +423,13 @@ def restore_ip_chain(esh_driver, esh_instance, redeploy=False,
     init_task.link(fixed_ip_task)
     # Add float and re-deploy OR just add floating IP...
     if redeploy:
+        core_identity = CoreIdentity.objects.get(uuid=core_identity_uuid)
         deploy_task = deploy_init_to.si(
             esh_driver.__class__,
             esh_driver.provider,
             esh_driver.identity,
             esh_instance.id,
+            core_identity,
             redeploy=True)
         fixed_ip_task.link(deploy_task)
     else:
@@ -1606,7 +1608,7 @@ def run_instance_action(user, identity, instance_id, action_type, action_params)
     elif 'revert_resize' == action_type:
         result_obj = esh_driver.revert_resize_instance(esh_instance)
     elif 'redeploy' == action_type:
-        result_obj = redeploy_init(esh_driver, esh_instance)
+        result_obj = redeploy_init(esh_driver, esh_instance, identity)
     elif 'resume' == action_type:
         result_obj = resume_instance(esh_driver, esh_instance,
                                      provider_uuid, identity_uuid,

--- a/service/licensing.py
+++ b/service/licensing.py
@@ -19,7 +19,7 @@ def create_license(title, description, created_by, allow_imaging=True):
     if is_url(description):
         license_type = LicenseType.objects.get(name="URL")
     else:
-        license_type = LicenseType.objects.get(name="Full Text")
+        license_type = LicenseType.objects.get(name="Raw Text")
     new_license = License(
         title=title,
         license_type=license_type,

--- a/service/task.py
+++ b/service/task.py
@@ -25,9 +25,9 @@ def print_task_chain(start_link):
     next_link = start_link
     while next_link.options.get('link'):
         if start_link == next_link:
-            print next_link.values()[0],
+            print next_link.values()[1],
         next_link = next_link.options['link'][0]
-        print "--> %s" % next_link.values()[0],
+        print "--> %s" % next_link.values()[1],
 
 
 def deploy_init_task(driver, instance, identity,
@@ -40,6 +40,7 @@ def deploy_init_task(driver, instance, identity,
                                 driver.provider,
                                 driver.identity,
                                 instance.alias,
+                                identity,
                                 username,
                                 password,
                                 redeploy,

--- a/service/tasks/driver.py
+++ b/service/tasks/driver.py
@@ -32,7 +32,7 @@ from core.models.instance import Instance
 from core.models.identity import Identity
 from core.models.profile import UserProfile
 
-from service.deploy import _inject_env_script, check_process, wrap_script, echo_test_script,\
+from service.deploy import inject_env_script, check_process, wrap_script, echo_test_script,\
     deploy_to as ansible_deploy_to
 from service.driver import get_driver, get_account_driver
 from service.exceptions import AnsibleDeployException
@@ -789,7 +789,7 @@ def _get_boot_script_chain(
         return first_task, end_task
     script_zero = deploy_boot_script.si(
             driverCls, provider, identity, instance_id,
-            _inject_env_script(core_identity.created_by.username),
+            inject_env_script(core_identity.created_by.username),
             "Inject ENV variables")
     first_task = script_zero
     end_task = script_zero # For now, its first and last. this will change.

--- a/service/tasks/driver.py
+++ b/service/tasks/driver.py
@@ -32,7 +32,7 @@ from core.models.instance import Instance
 from core.models.identity import Identity
 from core.models.profile import UserProfile
 
-from service.deploy import check_process, wrap_script, echo_test_script,\
+from service.deploy import _inject_env_script, check_process, wrap_script, echo_test_script,\
     deploy_to as ansible_deploy_to
 from service.driver import get_driver, get_account_driver
 from service.exceptions import AnsibleDeployException
@@ -408,7 +408,7 @@ def deploy_to(driverCls, provider, identity, instance_id, *args, **kwargs):
       default_retry_delay=20,
       ignore_result=True,
       max_retries=3)
-def deploy_init_to(driverCls, provider, identity, instance_id,
+def deploy_init_to(driverCls, provider, identity, instance_id, core_identity,
                    username=None, password=None, redeploy=False, deploy=True,
                    *args, **kwargs):
     try:
@@ -423,7 +423,7 @@ def deploy_init_to(driverCls, provider, identity, instance_id,
         image_metadata = driver._connection\
                                .ex_get_image_metadata(instance.source)
         deploy_chain = get_deploy_chain(
-            driverCls, provider, identity, instance,
+            driverCls, provider, identity, instance, core_identity,
             username=username, password=password,
             redeploy=redeploy, deploy=deploy)
         celery_logger.debug(
@@ -450,13 +450,14 @@ def get_deploy_chain(
         provider,
         identity,
         instance,
+        core_identity,
         username=None,
         password=None,
         redeploy=False,
         deploy=True):
     start_task = get_chain_from_build(
-        driverCls, provider, identity, instance, username=username,
-        password=password, redeploy=redeploy, deploy=deploy)
+        driverCls, provider, identity, instance, core_identity,
+        username=username, password=password, redeploy=redeploy, deploy=deploy)
     return start_task
 
 
@@ -465,6 +466,7 @@ def get_idempotent_deploy_chain(
         provider,
         identity,
         instance,
+        core_identity,
         username):
     """
     Takes an instance in ANY 'tmp_status' (Just launched or long-launched and recently started)
@@ -499,6 +501,7 @@ def get_idempotent_deploy_chain(
             provider,
             identity,
             instance,
+            core_identity,
             username=username,
             redeploy=False)
     elif tmp_status == 'networking':
@@ -510,6 +513,7 @@ def get_idempotent_deploy_chain(
             provider,
             identity,
             instance,
+            core_identity,
             username=username,
             redeploy=False)
     elif not instance.ip:
@@ -521,6 +525,7 @@ def get_idempotent_deploy_chain(
             provider,
             identity,
             instance,
+            core_identity,
             username=username,
             redeploy=False)
     elif tmp_status in ['deploying', 'deploy_error']:
@@ -532,6 +537,7 @@ def get_idempotent_deploy_chain(
             provider,
             identity,
             instance,
+            core_identity,
             username=username,
             redeploy=False)
     else:
@@ -557,9 +563,9 @@ def get_remove_status_chain(driverCls, provider, identity, instance):
     return start_chain
 
 
-def get_chain_from_build(driverCls, provider, identity, instance,
-                         username=None, password=None, redeploy=False,
-                         deploy=True):
+def get_chain_from_build(
+        driverCls, provider, identity, instance, core_identity,
+        username=None, password=None, redeploy=False, deploy=True):
     """
     Wait for instance to go to active.
     THEN Initialize the networking for the instance
@@ -569,7 +575,7 @@ def get_chain_from_build(driverCls, provider, identity, instance,
         instance.id, driverCls, provider, identity, "active")
     start_chain = wait_active_task
     network_start = get_chain_from_active_no_ip(
-        driverCls, provider, identity, instance, username=username,
+        driverCls, provider, identity, instance, core_identity, username=username,
         password=password, redeploy=redeploy, deploy=deploy)
     start_chain.link(network_start)
     return start_chain
@@ -589,9 +595,9 @@ def print_chain(start_task, idx=0):
         mystr += print_chain(task, idx+1)
     return mystr
 
-def get_chain_from_active_no_ip(driverCls, provider, identity, instance,
-                                username=None, password=None, redeploy=False,
-                                deploy=True):
+def get_chain_from_active_no_ip(
+        driverCls, provider, identity, instance, core_identity,
+        username=None, password=None, redeploy=False, deploy=True):
     """
     Initialize the networking for the instance
     THEN deploy to the box.
@@ -613,16 +619,16 @@ def get_chain_from_active_no_ip(driverCls, provider, identity, instance,
         start_chain.link(floating_task)
     end_chain = floating_task
     deploy_start = get_chain_from_active_with_ip(
-        driverCls, provider, identity, instance,
+        driverCls, provider, identity, instance, core_identity,
         username=username, password=password,
         redeploy=redeploy, deploy=deploy)
     end_chain.link(deploy_start)
     return start_chain
 
 
-def get_chain_from_active_with_ip(driverCls, provider, identity, instance,
-                                  username=None, password=None,
-                                  redeploy=False, deploy=True):
+def get_chain_from_active_with_ip(
+        driverCls, provider, identity, instance, core_identity,
+        username=None, password=None, redeploy=False, deploy=True):
     """
     Use Case: Instance has (or will be at start of this chain) an IP && is active.
     Goal: if 'Deploy' - Update metadata to inform you will be deploying
@@ -671,7 +677,7 @@ def get_chain_from_active_with_ip(driverCls, provider, identity, instance,
         driverCls, provider, identity, instance.id)
     # JUST before we finish, check for boot_scripts_chain
     boot_chain_start, boot_chain_end = _get_boot_script_chain(
-        driverCls, provider, identity, instance.id)
+        driverCls, provider, identity, instance.id, core_identity)
     # (SUCCESS_)LINKS and ERROR_LINKS
     deploy_task.link_error(
         deploy_failed.s(driverCls, provider, identity, instance.id))
@@ -773,38 +779,52 @@ def boot_script_failed(task_uuid, driverCls, provider, identity, instance_id,
         boot_script_failed.retry(exc=exc)
 
 
-def _get_boot_script_chain(driverCls, provider, identity, instance_id, remove_status=False):
+def _get_boot_script_chain(
+        driverCls, provider, identity, instance_id,
+        core_identity, remove_status=False):
     core_instance = Instance.objects.get(provider_alias=instance_id)
     scripts = get_scripts_for_instance(core_instance)
     first_task = end_task = None
     if not scripts:
         return first_task, end_task
+    script_zero = deploy_boot_script.si(
+            driverCls, provider, identity, instance_id,
+            _inject_env_script(core_identity.created_by.username),
+            "Inject ENV variables")
+    first_task = script_zero
+    end_task = script_zero # For now, its first and last. this will change.
     total = len(scripts)
     for idx, script in enumerate(scripts):
         # Name the status
-        if total > 1:
-            script_text = "running_boot_script: #%s/%s" % (idx + 1, total)
+        if total > 2:
+            script_text = "running_boot_script: #%s/%s" % (idx + 1, total - 1)
         else:
             script_text = "running_boot_script"
         # Update the status
         init_script_status_task = update_metadata.si(
             driverCls, provider, identity, instance_id,
             {'tmp_status': script_text})
-        if idx == 0:
-            first_task = init_script_status_task
-        if end_task:
-            end_task.link(init_script_status_task)
         # Execute script
         deploy_script_task = deploy_boot_script.si(
             driverCls, provider, identity, instance_id,
             script.get_text(), script.get_title_slug())
+
         # Linking...
-        init_script_status_task.link(deploy_script_task)
+        if idx == 0:
+            first_task = init_script_status_task  # Always first
+            init_script_status_task.link(script_zero)  # Inject 'script zero'
+            script_zero.link(deploy_script_task)  # Link first script after it
+            script_zero.link_error(
+                boot_script_failed.s(driverCls, provider, identity, instance_id))
+        else:
+            init_script_status_task.link(deploy_script_task)
+
         init_script_status_task.link_error(
             boot_script_failed.s(driverCls, provider, identity, instance_id))
         deploy_script_task.link_error(
             boot_script_failed.s(driverCls, provider, identity, instance_id))
         if idx + 1 == total and remove_status:
+            # Actions are slightly different if this is the final task
             clear_script_status_task = update_metadata.si(
                 driverCls, provider, identity, instance_id,
                 {'tmp_status': ''})
@@ -847,6 +867,9 @@ def destroy_instance(instance_alias, user, core_identity_uuid):
       max_retries=10)
 def deploy_script(driverCls, provider, identity, instance_id,
                   script, **celery_task_args):
+    """
+    #TODO: Should this be ansible now?
+    """
     try:
         celery_logger.debug("deploy_script task started at %s." % datetime.now())
         # Check if instance still exists
@@ -1049,6 +1072,7 @@ def check_process_task(driverCls, provider, identity,
     #NOTE: While this looks like a large number (250 ?!) of retries
     # we expect this task to fail often when the image is building
     # and large, uncached images can have a build time.
+    # TODO: This should be ansible-ized. Ansible will have already run by the time this process is started.
     """
     try:
         celery_logger.debug("check_process_task started at %s." % datetime.now())


### PR DESCRIPTION
This first PR include support for a single variable, $ATMO_USER that represents the user of the identity that created the instance.
Any other variables injected should also carry the $ATMO_ namespace.

Scripts that execute after this should be expected to "source the file $HOME/.bashrc for the deploying user (Usually root)".

A later version would ideally have ansible support. Will consult with @amercer1 about development on this front.

This will be patched into production to help a user get their image up and running properly.