### PR TITLE
API v2 fix email support keyword arg

### DIFF
--- a/core/email.py
+++ b/core/email.py
@@ -130,7 +130,7 @@ def send_email(subject, body, from_email, to, cc=None,
     return True
 
 
-def email_admin(request, subject, message,
+def email_admin(request, subject, message, data=None,
                 cc_user=True, request_tracker=False):
     """ Use request, subject and message to build and send a standard
         Atmosphere user request email. From an atmosphere user to admins.
@@ -139,8 +139,9 @@ def email_admin(request, subject, message,
     user_agent, remote_ip, location, resolution = request_info(request)
     user, user_email, user_name = lookup_user(request)
     # build email body.
-    body = u"%s\nLocation: %s\nSent From: %s - %s\nSent By: %s - %s"
+    body = u"%s\nData: %s\nLocation: %s\nSent From: %s - %s\nSent By: %s - %s"
     body %= (message,
+             data,
              location,
              user, remote_ip,
              user_agent, resolution)


### PR DESCRIPTION
When shifting to the API v2 `email_support` endpoint, I get an error regarding an unexpected keyword argument, `data`:

![screen shot 2016-02-02 at 12 21 54 pm](https://cloud.githubusercontent.com/assets/5923/12762553/e57a44e4-c9ac-11e5-8c20-55961c617a81.png)

It turns out the source of the error is a call to `email_admin` in the email view for `api/v2`:
```python
        email_success = email_admin(
            self.request, subject, message, data=data)
```
source: [api/v2/views/email.py](https://github.com/iPlantCollaborativeOpenSource/atmosphere/blob/kicking-kestrel/api/v2/views/email.py#L54-L62)

After popping off the required `subject` & `message` keys, we're trying to easily pass along any additional information that the UI provided as part of "extra data" in the message. 

But, `email_admin` doesn't expect this:
```python
def email_admin(request, subject, message,
                cc_user=True, request_tracker=False):
    # ...
```
source: [core/email.py](https://github.com/iPlantCollaborativeOpenSource/atmosphere/blob/kicking-kestrel/core/email.py#L133-L148)

This PR accepted `data=data` and included it in the support message that is sent. 

A sample rendering was captured from `atmosphere.log`:

```log
2016-02-02 12:36:37,309 atmosphere-INFO [/home/vagrant/gh/atmosphere/core/email.py 148] email_admin - body text: Volume ID: 1814
Provider ID: 4

Problems
  -Data is missing from my volume
  -Cannot transfer data on/off my volume
  -Other problem(s)

Details 
aljflksdjakflj

Data: {u'username': u'lenards', 'server': 'localhost', u'user-interface': u'troposphere'}
Location: No Location
Sent From: lenards - 192.168.72.1
Sent By: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.97 Safari/537.36 - No Resolution
```
