### PR TITLE
Add close action to machine request

### DIFF
--- a/api/v2/views/machine_request.py
+++ b/api/v2/views/machine_request.py
@@ -135,3 +135,4 @@ class MachineRequestViewSet(BaseRequestViewSet):
         """
         Silently close request
         """
+        pass

--- a/api/v2/views/machine_request.py
+++ b/api/v2/views/machine_request.py
@@ -130,3 +130,8 @@ class MachineRequestViewSet(BaseRequestViewSet):
         """
         Notify the user that the request was denied
         """
+
+    def close_action(self, instance):
+        """
+        Silently close request
+        """


### PR DESCRIPTION
Add function called when `request.is_closed()` is true. Currently has no functionality, but prevents an error from being thrown when an imaging request is denied.