### PR TITLE
Filter machine requests

### DIFF
--- a/api/v2/serializers/details/machine_request.py
+++ b/api/v2/serializers/details/machine_request.py
@@ -133,19 +133,20 @@ class MachineRequestSerializer(serializers.HyperlinkedModelSerializer):
             )
 
         # TODO: make sure user has access to parent machine
-
         return data
 
     uuid = serializers.CharField(read_only=True)
     identity = IdentityRelatedField(source='membership.identity',
-                                    queryset=Identity.objects.none())
+                                    queryset=Identity.objects.none(),
+                                    style={'base_template': 'input.html'})
     instance = ModelRelatedField(
         queryset=Instance.objects.all(),
         serializer_class=InstanceSummarySerializer,
         style={'base_template': 'input.html'})
     status = StatusTypeRelatedField(queryset=StatusType.objects.none(),
                                     allow_null=True,
-                                    required=False)
+                                    required=False,
+                                    style={'base_template': 'input.html'},)
     admin_message = serializers.CharField(read_only=True)
     parent_machine = ModelRelatedField(
        required = False, 

--- a/api/v2/views/machine_request.py
+++ b/api/v2/views/machine_request.py
@@ -30,6 +30,7 @@ class MachineRequestViewSet(BaseRequestViewSet):
     ordering_fields = ('start_date', 'end_date', 'new_machine_owner__username')
     ordering = ('-start_date',)
 
+    #TODO: find a better way to handle filtering than overriding BaseRequest get_queryset
     def get_queryset(self):
         """
         Return users requests or all the requests if the user is an admin.

--- a/api/v2/views/machine_request.py
+++ b/api/v2/views/machine_request.py
@@ -5,6 +5,7 @@ from api.v2.serializers.details import MachineRequestSerializer,\
 from api.v2.views.base import BaseRequestViewSet
 
 from django.db.models import Q
+from django.utils import timezone
 
 from core import exceptions as core_exceptions
 from core.email import send_denied_resource_email
@@ -17,6 +18,8 @@ from service.machine import share_with_admins, share_with_self, remove_duplicate
 from service.tasks.machine import start_machine_imaging
 from threepio import logger
 
+from datetime import timedelta
+
 
 class MachineRequestViewSet(BaseRequestViewSet):
     queryset = MachineRequest.objects.none()
@@ -27,6 +30,26 @@ class MachineRequestViewSet(BaseRequestViewSet):
     ordering_fields = ('start_date', 'end_date', 'new_machine_owner__username')
     ordering = ('-start_date',)
 
+    def get_queryset(self):
+        """
+        Return users requests or all the requests if the user is an admin.
+        """
+
+        assert self.model is not None, (
+            "%s should include a `model` attribute."
+            % self.__class__.__name__
+        )
+
+        to_return = MachineRequest.objects.filter((Q(start_date__gte=timezone.now() - timedelta(days=7)) |\
+            Q(status__name='pending')))
+
+        if self.request.query_params.get("all", "").lower() == "true":
+            to_return = MachineRequest.objects.all()
+
+        if self.request.user.is_staff:
+            return to_return.order_by('-start_date')
+    
+        return to_return.filter(created_by=self.request.user).order_by('-start_date')
 
     def perform_create(self, serializer):
 


### PR DESCRIPTION
By default, `/api/v2/machine_requests` will display only active requests and all requests made within the past 7 days.

All requests can be returned by adding `?all=true` as a query param.