### PR TITLE
Add filtering to instance status history

### DIFF
--- a/api/v2/views/instance_history.py
+++ b/api/v2/views/instance_history.py
@@ -37,7 +37,7 @@ class InstanceStatusHistoryViewSet(MultipleFieldLookup, AuthReadOnlyViewSet):
     queryset = InstanceStatusHistory.objects.all()
     serializer_class = InstanceStatusHistorySerializer
     ordering = ('-instance__start_date', 'instance__id')
-    ordering_fields = ('-instance__start_date', 'instance__id')
+    ordering_fields = ('start_date', 'instance__id')
     lookup_fields = ("id", "uuid")
     filter_class = InstanceStatusHistoryFilter
     filter_backends = (filters.OrderingFilter, filters.DjangoFilterBackend)

--- a/api/v2/views/instance_history.py
+++ b/api/v2/views/instance_history.py
@@ -36,8 +36,8 @@ class InstanceStatusHistoryViewSet(MultipleFieldLookup, AuthReadOnlyViewSet):
     """
     queryset = InstanceStatusHistory.objects.all()
     serializer_class = InstanceStatusHistorySerializer
-    ordering = ('-start_date', 'instance__id')
-    ordering_fields = ('start_date', 'instance__id')
+    ordering = ('-instance__start_date', 'instance__id')
+    ordering_fields = ('-instance__start_date', 'instance__id')
     lookup_fields = ("id", "uuid")
     filter_class = InstanceStatusHistoryFilter
     filter_backends = (filters.OrderingFilter, filters.DjangoFilterBackend)
@@ -47,4 +47,8 @@ class InstanceStatusHistoryViewSet(MultipleFieldLookup, AuthReadOnlyViewSet):
         Filter out tags for deleted instances
         """
         user_id = self.request.user.id
+
+        if self.request.query_params.get('unique', "").lower() == 'true':
+            return InstanceStatusHistory.objects.filter(instance__created_by_id=user_id).distinct('instance__start_date')
+
         return InstanceStatusHistory.objects.filter(instance__created_by_id=user_id)

--- a/api/v2/views/instance_history.py
+++ b/api/v2/views/instance_history.py
@@ -37,7 +37,7 @@ class InstanceStatusHistoryViewSet(MultipleFieldLookup, AuthReadOnlyViewSet):
     queryset = InstanceStatusHistory.objects.all()
     serializer_class = InstanceStatusHistorySerializer
     ordering = ('-instance__start_date', 'instance__id')
-    ordering_fields = ('start_date', 'instance__id')
+    ordering_fields = ('-instance__start_date', '-start_date', 'instance__id')
     lookup_fields = ("id", "uuid")
     filter_class = InstanceStatusHistoryFilter
     filter_backends = (filters.OrderingFilter, filters.DjangoFilterBackend)

--- a/api/v2/views/instance_history.py
+++ b/api/v2/views/instance_history.py
@@ -49,6 +49,8 @@ class InstanceStatusHistoryViewSet(MultipleFieldLookup, AuthReadOnlyViewSet):
         user_id = self.request.user.id
 
         if self.request.query_params.get('unique', "").lower() == 'true':
+            # filtering distinct instance__start_date effectively gives us a unique instance list. Also the order of fields in distinct() 
+            # must match the order of fields in ordering set above
             return InstanceStatusHistory.objects.filter(instance__created_by_id=user_id).distinct('instance__start_date')
 
         return InstanceStatusHistory.objects.filter(instance__created_by_id=user_id)


### PR DESCRIPTION
We currently treat "instance status history" as an instance launch history in Troposphere, displaying the list as a list of the instances you've launched.

This list is actually a list of all instance statuses, meaning one instance has multiple entries in the list, which goes against how we've been using it.

This PR allows for filtering `unique=True` to get a list with unique instance IDs, effectively giving us a list of the instances a user has launched.