### PR TITLE
Include new endpoint `/api/status/celery`

### DIFF
--- a/api/status/urls.py
+++ b/api/status/urls.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""
+Routes for api status endpoints
+"""
+from django.conf.urls import patterns, include, url
+from rest_framework import routers
+
+from api.status import views
+
+router = routers.DefaultRouter(trailing_slash=False)
+router.register(r'celery', views.CeleryViewSet, base_name='celery')
+
+api_status_urls = router.urls
+urlpatterns = patterns('', url(r'^', include(api_status_urls)),)

--- a/api/status/views/__init__.py
+++ b/api/status/views/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa
+from .celery import CeleryViewSet

--- a/api/status/views/celery.py
+++ b/api/status/views/celery.py
@@ -4,6 +4,22 @@ from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 
 
+def _is_celery_running():
+    """
+    Verify whether or not celery workers are running
+    return True/False
+    """
+    ps = subprocess.Popen(
+        ['ps', 'aux'], stdout=subprocess.PIPE)
+    try:
+        output = subprocess.check_output(
+            ['grep', '[c]elery worker'], stdin=ps.stdout)
+        return output is not ""
+    except subprocess.CalledProcessError:
+        # Grep returns exit-code 1 if no match
+        return False
+
+
 class CeleryViewSet(ViewSet):
 
     """
@@ -15,12 +31,8 @@ class CeleryViewSet(ViewSet):
         At time of request, check the current status
         of celery and return back 'the status'.
         """
-        ps = subprocess.Popen(
-            ['ps', 'aux'], stdout=subprocess.PIPE)
-        output = subprocess.check_output(
-            ['grep', '[c]elery worker'], stdin=ps.stdout)
-
-        if output:
+        result = _is_celery_running()
+        if result:
             resp = {'status': 200, 'message': "Celery is running"}
             status_code = 200
         else:

--- a/api/status/views/celery.py
+++ b/api/status/views/celery.py
@@ -1,0 +1,30 @@
+import subprocess
+
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+
+
+class CeleryViewSet(ViewSet):
+
+    """
+    API endpoint that prints the status of celery
+    """
+
+    def list(self, request):
+        """
+        At time of request, check the current status
+        of celery and return back 'the status'.
+        """
+        ps = subprocess.Popen(
+            ['ps', 'aux'], stdout=subprocess.PIPE)
+        output = subprocess.check_output(
+            ['grep', '[c]elery worker'], stdin=ps.stdout)
+
+        if output:
+            resp = {'status': 200, 'message': "Celery is running"}
+            status_code = 200
+        else:
+            resp = {'status': 404, 'message': "Celery is NOT running"}
+            status_code = 404
+
+        return Response(resp, status=status_code)

--- a/api/urls.py
+++ b/api/urls.py
@@ -9,4 +9,6 @@ urlpatterns = patterns(
     '',
     url(r'', include("api.v2.urls", namespace="default")),
     url(r'^v1/', include("api.v1.urls", namespace="v1")),
-    url(r'^v2/', include("api.v2.urls", namespace="v2")))
+    url(r'^v2/', include("api.v2.urls", namespace="v2")),
+    url(r'^status/', include("api.status.urls", namespace="status"))
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,9 @@ django-redis-cache==0.13.0
 redis==2.10.3
 
 Jinja2==2.8
-celery==3.1.18
-django-celery==3.1.16
+celery==3.1.20
+flower==0.8.4
+django-celery==3.1.17
 
 gevent==1.0.1
 


### PR DESCRIPTION
Endpoint was created at the request of QA, who would like to determine if celery is running prior to executing API tests.

If celery is running, the API returns:
```
HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "status": 200,
    "message": "Celery is running"
}
```

If celery is NOT running, the API returns:
```
HTTP 404 Not Found
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "status": 404,
    "message": "Celery is NOT running"
}
```