### PR TITLE
Update delete project requirements

### DIFF
--- a/api/v2/views/maintenance_record.py
+++ b/api/v2/views/maintenance_record.py
@@ -28,7 +28,7 @@ class MaintenanceRecordViewSet(AuthOptionalViewSet):
     """
     API endpoint that allows records to be viewed or edited.
     """
-    http_method_names = ['get', 'post', 'put', 'patch', 'head', 'options', 'trace']
+    http_method_names = ['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace']
     queryset = MaintenanceRecord.objects.order_by('-start_date')
     permission_classes = (CanEditOrReadOnly,)
     serializer_class = MaintenanceRecordSerializer

--- a/api/v2/views/maintenance_record.py
+++ b/api/v2/views/maintenance_record.py
@@ -1,11 +1,27 @@
+import django_filters
+
+from rest_framework import filters
 from rest_framework.serializers import ValidationError
 
-from core.models import MaintenanceRecord
+from core.models import AtmosphereUser, MaintenanceRecord
+from core.query import only_current
 
 from api.permissions import CanEditOrReadOnly
 from api.v2.serializers.details import MaintenanceRecordSerializer
 from api.v2.views.base import AuthOptionalViewSet
 
+
+class MaintenanceRecordFilterBackend(filters.BaseFilterBackend):
+    """
+    Filter MaintenanceRecords using the request_user and 'query_params'
+    """
+    def filter_queryset(self, request, queryset, view):
+        request_params = request.query_params
+        active = request_params.get('active')
+        if isinstance(active, basestring) and active.lower() == 'true'\
+                or isinstance(active, bool) and active:
+            queryset = MaintenanceRecord.active()
+        return queryset
 
 class MaintenanceRecordViewSet(AuthOptionalViewSet):
 
@@ -16,3 +32,4 @@ class MaintenanceRecordViewSet(AuthOptionalViewSet):
     queryset = MaintenanceRecord.objects.order_by('-start_date')
     permission_classes = (CanEditOrReadOnly,)
     serializer_class = MaintenanceRecordSerializer
+    filter_backends = (filters.DjangoFilterBackend, filters.SearchFilter, MaintenanceRecordFilterBackend)

--- a/api/v2/views/project.py
+++ b/api/v2/views/project.py
@@ -27,6 +27,16 @@ class ProjectViewSet(MultipleFieldLookup, AuthViewSet):
                 "Cannot delete a project when it contains instances."
                 " To delete a project, all instances must be moved "
                 "to another project or deleted")
+        elif project.applications.filter(end_date__isnull=True).count() > 0:
+            raise ValidationError(
+                "Cannot delete a project when it contains instances."
+                " To delete a project, all Images must be moved "
+                "to another project or deleted")
+        elif project.links.all().count() > 0:
+            raise ValidationError(
+                "Cannot delete a project when it contains instances."
+                " To delete a project, all External Links must be moved "
+                "to another project or deleted")
         elif project.volumes.filter(
                 instance_source__end_date__isnull=True).count() > 0:
             raise ValidationError(

--- a/api/v2/views/project.py
+++ b/api/v2/views/project.py
@@ -31,7 +31,7 @@ class ProjectViewSet(MultipleFieldLookup, AuthViewSet):
             raise ValidationError(
                 "Cannot delete a project when it contains instances."
                 " To delete a project, all Images must be moved "
-                "to another project or deleted")
+                "to another project or removed from the project.")
         elif project.links.all().count() > 0:
             raise ValidationError(
                 "Cannot delete a project when it contains instances."


### PR DESCRIPTION
Don't allow API deletion of a Project until all Project Resources (Including newly-added External Links and Applications/Images) are moved out of the project.