### PR TITLE
Filter image version machines

### DIFF
--- a/api/v2/serializers/details/image_version.py
+++ b/api/v2/serializers/details/image_version.py
@@ -1,6 +1,7 @@
 from core.models import ApplicationVersion as ImageVersion
 from core.models import Application as Image
 from core.models import License, BootScript
+from core.models import ProviderMachine
 from rest_framework import serializers
 from api.v2.serializers.summaries import (
     BootScriptSummarySerializer,
@@ -8,10 +9,13 @@ from api.v2.serializers.summaries import (
     UserSummarySerializer,
     ImageSummarySerializer,
     IdentitySummarySerializer,
+    ProviderMachineSummarySerializer,
     ImageVersionSummarySerializer)
 from api.v2.serializers.fields import (
     ProviderMachineRelatedField, ModelRelatedField)
 from api.v2.serializers.fields.base import UUIDHyperlinkedIdentityField
+from django.db.models import Q
+from django.contrib.auth.models import AnonymousUser
 
 
 class ImageVersionSerializer(serializers.HyperlinkedModelSerializer):
@@ -37,7 +41,7 @@ class ImageVersionSerializer(serializers.HyperlinkedModelSerializer):
         many=True)  # NEW
     user = UserSummarySerializer(source='created_by')
     identity = IdentitySummarySerializer(source='created_by_identity')
-    machines = ProviderMachineRelatedField(many=True)
+    machines = serializers.SerializerMethodField('get_machines_for_user')
     image = ModelRelatedField(
         source='application',
         queryset=Image.objects.all(),
@@ -51,6 +55,22 @@ class ImageVersionSerializer(serializers.HyperlinkedModelSerializer):
         view_name='api:v2:imageversion-detail',
         uuid_field='id'
     )
+
+    def get_machines_for_user(self, obj):
+        """
+        Only show version as available on providers the user has access to
+        """
+        user = self.context['request'].user
+        if isinstance(user, AnonymousUser):
+            filtered = obj.machines.filter(Q(instance_source__provider__public=True))
+        else:
+            filtered = obj.machines.filter(Q(instance_source__provider_id__in=user.provider_ids()))
+        serializer = ProviderMachineSummarySerializer(
+           filtered,
+           context=self.context,
+           many=True)
+        return serializer.data
+
     class Meta:
         model = ImageVersion
         fields = ('id', 'url', 'parent', 'name', 'change_log',

--- a/api/v2/serializers/details/image_version.py
+++ b/api/v2/serializers/details/image_version.py
@@ -61,9 +61,11 @@ class ImageVersionSerializer(serializers.HyperlinkedModelSerializer):
         Only show version as available on providers the user has access to
         """
         user = self.context['request'].user
+
+        filtered = obj.machines
         if isinstance(user, AnonymousUser):
             filtered = obj.machines.filter(Q(instance_source__provider__public=True))
-        else:
+        elif not user.is_staff:
             filtered = obj.machines.filter(Q(instance_source__provider_id__in=user.provider_ids()))
         serializer = ProviderMachineSummarySerializer(
            filtered,

--- a/core/models/application.py
+++ b/core/models/application.py
@@ -10,7 +10,7 @@ from threepio import logger
 
 from atmosphere import settings
 
-from core.query import only_current, only_current_apps, only_current_source
+from core.query import only_current, only_current_apps, only_public_apps, only_current_source
 from core.models.provider import Provider, AccountProvider
 from core.models.identity import Identity
 from core.models.tag import Tag, updateTags
@@ -86,7 +86,7 @@ class Application(models.Model):
     @classmethod
     def public_apps(cls):
         public_images = Application.objects.filter(
-            only_current_apps(), private=False)
+            only_current_apps(), private=False).filter(only_public_apps())
         return public_images
 
     @classmethod

--- a/core/models/application.py
+++ b/core/models/application.py
@@ -86,7 +86,7 @@ class Application(models.Model):
     @classmethod
     def public_apps(cls):
         public_images = Application.objects.filter(
-            only_current_apps(), only_public_apps(), private=False)
+            only_current_apps(), private=False).filter(only_public_apps())
         return public_images
 
     @classmethod

--- a/core/models/application.py
+++ b/core/models/application.py
@@ -10,7 +10,7 @@ from threepio import logger
 
 from atmosphere import settings
 
-from core.query import only_current, only_current_apps, only_public_apps, only_current_source
+from core.query import only_current, only_current_apps, only_current_source
 from core.models.provider import Provider, AccountProvider
 from core.models.identity import Identity
 from core.models.tag import Tag, updateTags
@@ -86,7 +86,7 @@ class Application(models.Model):
     @classmethod
     def public_apps(cls):
         public_images = Application.objects.filter(
-            only_current_apps(), private=False).filter(only_public_apps())
+            only_current_apps(), private=False)
         return public_images
 
     @classmethod

--- a/core/models/application.py
+++ b/core/models/application.py
@@ -86,7 +86,7 @@ class Application(models.Model):
     @classmethod
     def public_apps(cls):
         public_images = Application.objects.filter(
-            only_current_apps(), private=False).filter(only_public_apps())
+            only_current_apps(), only_public_apps(), private=False)
         return public_images
 
     @classmethod

--- a/core/query.py
+++ b/core/query.py
@@ -119,10 +119,19 @@ def only_current_apps(now_time=None):
         * ALL versions of this application have been end dated.
         """
         pass
+
     if not now_time:
         now_time = timezone.now()
     return _in_range() & _versions_in_range() & _machines_in_range() & _active_provider()
 
+
+def only_public_apps(now_time=None):
+    def _is_public():
+        return (Q(versions__machines__instance_source__provider__public=True))
+    if not now_time:
+        now_time = timezone.now()
+    return _is_public()
+    
 
 def only_current_machines_in_version(now_time=None):
     def _active_provider():

--- a/core/query.py
+++ b/core/query.py
@@ -165,6 +165,11 @@ def only_current_source(now_time=None):
         now_time = timezone.now()
     return _in_range() & _active_provider()
 
+
+def only_public_providers(now_time=None):
+    return (Q(instance_source__provider__public=True))
+
+
 def source_in_range(now_time=None):
     """
     Filters current instance_sources ignoring provider.

--- a/core/query.py
+++ b/core/query.py
@@ -119,19 +119,10 @@ def only_current_apps(now_time=None):
         * ALL versions of this application have been end dated.
         """
         pass
-
     if not now_time:
         now_time = timezone.now()
     return _in_range() & _versions_in_range() & _machines_in_range() & _active_provider()
 
-
-def only_public_apps(now_time=None):
-    def _is_public():
-        return (Q(versions__machines__instance_source__provider__public=True))
-    if not now_time:
-        now_time = timezone.now()
-    return _is_public()
-    
 
 def only_current_machines_in_version(now_time=None):
     def _active_provider():

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ python-ldap==2.4.19
 uWSGI==2.0.9
 
 ## ours
-django-iplant-auth==0.1.6
+django-iplant-auth==0.1.9
 threepio==0.2.0
 rtwo==0.3.8
 caslib.py==2.2.2


### PR DESCRIPTION
Filter displayed machines an image version is available on, based on whether or not the user has access to the cloud the provider machine exists on.

This is done for the ProviderMachine viewset itself, and the nested `machines` field within an image version.