### PR TITLE
Add volume serializer start date

### DIFF
--- a/api/v2/serializers/details/volume.py
+++ b/api/v2/serializers/details/volume.py
@@ -108,4 +108,4 @@ class UpdateVolumeSerializer(serializers.ModelSerializer):
     class Meta:
         model = Volume
         view_name = 'api:v2:volume-detail'
-        fields = ('name', 'description')
+        fields = ('name', 'description', 'start_date')

--- a/api/v2/serializers/details/volume.py
+++ b/api/v2/serializers/details/volume.py
@@ -104,8 +104,9 @@ class VolumeSerializer(serializers.HyperlinkedModelSerializer):
 class UpdateVolumeSerializer(serializers.ModelSerializer):
     name = serializers.CharField(required=False)
     description = serializers.CharField(required=False)
+    status = serializers.CharField(source='esh_status')
 
     class Meta:
         model = Volume
         view_name = 'api:v2:volume-detail'
-        fields = ('name', 'description', 'start_date')
+        fields = ('name', 'description', 'start_date', 'status')


### PR DESCRIPTION
Addresses ATMO-1116
Add `start_date` and `status` fields into VolumeUpdateSerializer, so that the response contains more relevant information.
Example in Troposphere
Before:
![zibfg0sm13](https://cloud.githubusercontent.com/assets/11079642/14161743/d9b2d02a-f69a-11e5-9039-52a9d66fb6a4.gif)

After:
![esyc6snpqd](https://cloud.githubusercontent.com/assets/11079642/14161635/38e445de-f69a-11e5-8838-a802fd2abc00.gif)
This happens because backbone will take the response from the API and set its model to have the same attributes as the response. Since the response only contains partial information, the backbone model only contains a name and description until the volume is fetched again and the attributes are updated.
