### PR TITLE
Add machine request filtering

### DIFF
--- a/api/v2/views/machine_request.py
+++ b/api/v2/views/machine_request.py
@@ -26,7 +26,7 @@ class MachineRequestViewSet(BaseRequestViewSet):
     model = MachineRequest
     serializer_class = UserMachineRequestSerializer
     admin_serializer_class = MachineRequestSerializer
-    filter_fields = ('status__id', 'status__name', 'new_machine_owner__username', 'start_date')
+    filter_fields = ('status__id', 'status__name', 'new_machine_owner__username')
     ordering_fields = ('start_date', 'end_date', 'new_machine_owner__username')
     ordering = ('-start_date',)
 

--- a/api/v2/views/machine_request.py
+++ b/api/v2/views/machine_request.py
@@ -34,7 +34,7 @@ class MachineRequestViewSet(BaseRequestViewSet):
         if 'active' in self.request.query_params:
             all_active = MachineRequest.objects.filter(
                 (
-                    Q(status__name='pending') |
+                    ~Q(status__name='closed') |
                     Q(start_date__gt=timezone.now() - timedelta(days=7))
                 )
             )

--- a/api/v2/views/machine_request.py
+++ b/api/v2/views/machine_request.py
@@ -32,12 +32,17 @@ class MachineRequestViewSet(BaseRequestViewSet):
 
     def get_queryset(self):
         if 'active' in self.request.query_params:
-            return MachineRequest.objects.filter(
+            all_active = MachineRequest.objects.filter(
                 (
                     Q(status__name='pending') |
                     Q(start_date__gt=timezone.now() - timedelta(days=7))
                 )
             )
+            if self.request.user.is_staff:
+                return all_active.order_by('-start_date')
+            return all_active.filter(
+                created_by=self.request.user
+                ).order_by('-start_date')
         return super(MachineRequestViewSet, self).get_queryset()
 
     def perform_create(self, serializer):


### PR DESCRIPTION
If `?active=true` when retrieving machine requests, only display requests that are currently pending or have been created in the past 7 days.