### PR TITLE
Fixed a bug with default Quotas and Allocations.

### DIFF
--- a/core/models/allocation_strategy.py
+++ b/core/models/allocation_strategy.py
@@ -60,8 +60,8 @@ class Allocation(models.Model):
     @classmethod
     def default_dict(self):
         return {
-            'threshold': self._meta.get_field('threshold').default,
-            'delta': self._meta.get_field('delta').default
+            'threshold': self._meta.get_field('threshold').default(),
+            'delta': self._meta.get_field('delta').default()
         }
 
     class Meta:

--- a/core/models/quota.py
+++ b/core/models/quota.py
@@ -104,11 +104,11 @@ class Quota(models.Model):
     @classmethod
     def default_dict(cls):
         return {
-            'cpu': cls._meta.get_field('cpu').default,
-            'memory': cls._meta.get_field('memory').default,
-            'storage': cls._meta.get_field('storage').default,
-            'storage_count': cls._meta.get_field('storage_count').default,
-            'suspended_count': cls._meta.get_field('suspended_count').default
+            'cpu': cls._meta.get_field('cpu').default(),
+            'memory': cls._meta.get_field('memory').default(),
+            'storage': cls._meta.get_field('storage').default(),
+            'storage_count': cls._meta.get_field('storage_count').default(),
+            'suspended_count': cls._meta.get_field('suspended_count').default()
         }
 
     class Meta:


### PR DESCRIPTION
Some of the Django ORM code was trying to cast the callable 'default' functions to 'int'. Probably because the more recent ORM code assumes that arguments to queryset methods can't be callable.

I couldn't find anywhere where my change should be a problem, but somebody had better check my assumption.

See:

- <https://github.com/django/django/pull/2091>
- <https://code.djangoproject.com/ticket/11629>