### PR TITLE
Fixed incorrect attribute name problem in allocation.models.inputs.Ma…

### DIFF
--- a/allocation/models/inputs.py
+++ b/allocation/models/inputs.py
@@ -61,7 +61,7 @@ class Machine(object):
         return self.__unicode__()
 
     def __unicode__(self):
-        return "<Machine:%s %s>" % (self.name, self.instance_source.identifier)
+        return "<Machine:%s %s>" % (self.name, self.identifier)
 
 
 class Size(object):


### PR DESCRIPTION
…chine#__unicode__: `self.instance_source.identifier` should be `self.identifier`