### PR TITLE
Remove 'Name:' which gets interpretted by RT as command

### DIFF
--- a/core/templates/core/email/feedback.html
+++ b/core/templates/core/email/feedback.html
@@ -1,4 +1,4 @@
-Name: {{ user.get_full_name }} ({{ user.get_username }})
+Username: {{ user.get_username }} ({{ user.get_full_name }})
 
 Feedback: {{ feedback }}
 


### PR DESCRIPTION
Just a simple template change. RT tries to interpret the `Name:` header as a command.
When this gets merged, I'll cherry into NN.
