### PR TITLE
Ansible2.x Integration

### DIFF
--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -208,6 +208,7 @@ ANSIBLE_HOST_FILE = os.path.join(ANSIBLE_ROOT, 'ansible/hosts')
 ANSIBLE_PLAYBOOKS_DIR = os.path.join(ANSIBLE_ROOT, 'ansible/playbooks')
 ANSIBLE_ROLES_PATH = os.path.join(ANSIBLE_ROOT, 'ansible/roles')
 
+os.environ["ANSIBLE_CONFIG"] = ANSIBLE_CONFIG_FILE 
 
 # LOGSTASH
 LOGSTASH_HOST = '{{ LOGSTASH_HOST }}'

--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -205,6 +205,7 @@ ANSIBLE_ROOT = '{{ ANSIBLE_ROOT }}'
 # run and will warn that ansible is no configured.
 ANSIBLE_CONFIG_FILE = os.path.join(ANSIBLE_ROOT, 'ansible/ansible.cfg')
 ANSIBLE_HOST_FILE = os.path.join(ANSIBLE_ROOT, 'ansible/hosts')
+ANSIBLE_GROUP_VARS_DIR = os.path.join(ANSIBLE_ROOT, 'ansible/group_vars')
 ANSIBLE_PLAYBOOKS_DIR = os.path.join(ANSIBLE_ROOT, 'ansible/playbooks')
 ANSIBLE_ROLES_PATH = os.path.join(ANSIBLE_ROOT, 'ansible/roles')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,4 @@ threepio==0.2.0
 rtwo==0.3.8
 caslib.py==2.2.2
 chromogenic==0.2.1
-subspace==0.1.8
+subspace==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,4 @@ threepio==0.2.0
 rtwo==0.3.8
 caslib.py==2.2.2
 chromogenic==0.2.1
-subspace==0.1.7
+subspace==0.1.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,4 @@ threepio==0.2.0
 rtwo==0.3.8
 caslib.py==2.2.2
 chromogenic==0.2.1
-subspace==0.1.6
+subspace==0.1.7

--- a/service/deploy.py
+++ b/service/deploy.py
@@ -286,6 +286,8 @@ def configure_ansible():
         "DEFAULT_ROLES_PATH", settings.ANSIBLE_ROLES_PATH)
     if settings.ANSIBLE_CONFIG_FILE:
         os.environ["ANSIBLE_CONFIG"] = settings.ANSIBLE_CONFIG_FILE
+        # os.environ["ANSIBLE_DEBUG"] = "true"
+        # Alternatively set this in ansible.cfg: debug = true
         subspace.constants.reload_config()
 
 
@@ -351,11 +353,12 @@ def cache_bust(hostname):
 def log_playbook_summaries(logger, pb_runners, hostname):
     if not type(pb_runners) == list:
         pb_runners = [pb_runners]
+    # No point printing playbooks when using custom subspace stats
     summaries = [
-            (pbr.playbooks, pbr.stats.summarize(hostname))
+            pbr.stats.summarize(hostname)
             for pbr in pb_runners]
-    for filename_list, summary in summaries:
-        logger.info(get_playbook_filename(','.join(filename_list)) + str(summary))
+    for summary in summaries:
+        logger.info(str(summary))
 
 
 def get_playbook_filename(filename):

--- a/service/deploy.py
+++ b/service/deploy.py
@@ -174,6 +174,7 @@ def execute_playbooks(playbook_path, host_list, extra_vars, my_limit,
         playbook,
         host_list=host_list,
         limit_hosts=my_limit,
+        group_vars_map={filename: os.path.join(settings.ANSIBLE_GROUP_VARS_DIR,filename) for filename in os.listdir(settings.ANSIBLE_GROUP_VARS_DIR)},
         private_key=settings.ATMOSPHERE_PRIVATE_KEYFILE,
         extra_vars=extra_vars) for playbook in playbooks]
     [runner.run() for runner in runners]

--- a/service/deploy.py
+++ b/service/deploy.py
@@ -208,9 +208,8 @@ def ready_to_deploy(instance_ip, username, instance_id):
                   "VNCLICENSE": secrets.ATMOSPHERE_VNC_LICENSE,
                   "USERSSHKEYS": user_keys}
 
-    pbs = execute_playbooks(deploy_playbooks, host_list, extra_vars, my_limit,
-                            limit_playbooks=['10_atmo_pre_setup.yml',
-                                             '15_atmo_ntp.yml'])
+    pbs = execute_playbooks(util_playbooks, host_list, extra_vars, my_limit,
+                            limit_playbooks=['check_networking.yml'])
     log_playbook_summaries(logger, pbs, hostname)
     raise_playbook_errors(pbs, hostname)
     cache_bust(hostname)
@@ -332,6 +331,9 @@ def execution_has_failures(pbs, hostname):
     return any(pb.stats.failures for pb in pbs)
 
 def raise_playbook_errors(pbs, hostname, allow_failures=False):
+    """
+    """
+    # FIXME: stats.X[hostname] failing here. We should fix before moving into production
     error_message = ""
     for pb in pbs:
         if pb.stats.dark:

--- a/service/deploy.py
+++ b/service/deploy.py
@@ -92,7 +92,7 @@ class LoggedScriptDeployment(ScriptDeployment):
         return node
 
 
-def deploy_to(instance_ip, username, instance_id):
+def deploy_to(instance_ip, username, instance_id, limit_playbooks=None):
     """
     Use service.ansible to deploy to an instance.
     """
@@ -118,7 +118,7 @@ def deploy_to(instance_ip, username, instance_id):
 
     pbs = execute_playbooks(
         deploy_playbooks, host_file, extra_vars, my_limit,
-        logger=logger)
+        logger=logger, limit_playbooks=limit_playbooks)
     log_playbook_summaries(logger, pbs, hostname)
     raise_playbook_errors(pbs, instance_ip, hostname)
     cache_bust(hostname)


### PR DESCRIPTION
These changes are required to get ansible 2.0 working with atmosphere-ansible.

Notably, Isolating the method for creating and deploying playbooks and updating its implementation to use the 'subspace.playbook_2' for all deployments.

NOTE: Looks like changes for `scripts/add_new_accounts.py` have slipped into this migration. These can be ignored and evaluated separately..

DEPENDENCIES:
* [Atmosphere-ansible PR](https://github.com/iPlantCollaborativeOpenSource/atmosphere-ansible/pull/22)
* [Atmosphere PR](https://github.com/iPlantCollaborativeOpenSource/atmosphere/pull/134)
* [Subspace PR](https://github.com/iPlantCollaborativeOpenSource/subspace/pull/2)