### PR TITLE
Glance name optionally includes version name

### DIFF
--- a/atmosphere/settings/__init__.py
+++ b/atmosphere/settings/__init__.py
@@ -194,11 +194,16 @@ AUTH_SERVER_URL = SERVER_URL + REDIRECT_URL + '/auth'
 INIT_SCRIPT_PREFIX = '/init_files/'
 DEPLOY_SERVER_URL = SERVER_URL.replace("https", "http")
 
-# Stops 500 errors when logs are missing.
-# NOTE: If the permissions are wrong, this won't help
+# ATMOSPHERE NAMING CONVENTIONS
+# NOTE: If these values are overriden often, make this configurable
+APPLICATION_VERSION_SEPARATOR = "Version:"
 
 
 def check_and_touch(file_path):
+    """
+    Stops 500 errors when logs are missing.
+    NOTE: If the permissions are wrong, this won't help
+    """
     if os.path.exists(file_path):
         return
     parent_dir = os.path.dirname(file_path)

--- a/core/models/machine.py
+++ b/core/models/machine.py
@@ -229,7 +229,8 @@ def get_cached_machine(provider_alias, provider_id):
 
 
 def get_or_create_provider_machine(image_id, machine_name,
-                                   provider_uuid, app=None, version=None):
+                                   provider_uuid, app=None, version=None,
+                                   version_name="1.0"):
     """
     Guaranteed Return of ProviderMachine.
     1. Load provider machine from DB
@@ -252,7 +253,7 @@ def get_or_create_provider_machine(image_id, machine_name,
     if not version:
         version = get_version_for_machine(provider_uuid, image_id, fuzzy=True)
     if not version:
-        version = create_app_version(app, "1.0", provider_machine_id=image_id)
+        version = create_app_version(app, version_name, provider_machine_id=image_id)
 
     if type(version) in [models.QuerySet, list]:
         version = version[0]

--- a/core/models/machine.py
+++ b/core/models/machine.py
@@ -308,16 +308,16 @@ def update_application_owner(application, identity):
         print "Removed access to %s for %s" % (image_id, old_tenant_name)
 
 
-def provider_machine_update_hook(new_machine, provider_uuid, identifier):
+def read_cloud_machine_hook(new_machine, provider_uuid, identifier):
     """
     RULES:
     #1. READ operations ONLY!
     #2. FROM Cloud --> ProviderMachine ONLY!
     """
-    from service.openstack import glance_update_machine
+    from service.openstack import glance_read_machine
     provider = Provider.objects.get(uuid=provider_uuid)
     if provider.get_type_name().lower() == 'openstack':
-        glance_update_machine(new_machine)
+        glance_read_machine(new_machine)
     else:
         logger.warn(
             "machine data for %s is likely incomplete."
@@ -356,7 +356,7 @@ def create_provider_machine(identifier, provider_uuid, app,
         instance_source=source,
         application_version=version,
     )
-    provider_machine_update_hook(provider_machine, provider_uuid, identifier)
+    read_cloud_machine_hook(provider_machine, provider_uuid, identifier)
     logger.info("New ProviderMachine created: %s" % provider_machine)
     add_to_cache(provider_machine)
     return provider_machine

--- a/core/models/machine.py
+++ b/core/models/machine.py
@@ -3,6 +3,7 @@
 """
 from hashlib import md5
 
+from django.conf import settings
 from django.db import models
 from django.utils import timezone
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist as DoesNotExist
@@ -53,6 +54,38 @@ class ProviderMachine(BaseSource):
         return ProviderMachine.objects.filter(
             instance_source__identifier=identifier,
             instance_source__provider=provider).count()
+
+    @classmethod
+    def _split_cloud_name(cls, machine_name):
+        version_sep = settings.APPLICATION_VERSION_SEPARATOR
+        if version_sep in machine_name:
+            split_list = machine_name.split(version_sep)
+
+        if len(split_list) == 1:
+            logger.warn(
+                "Version separator(%s) was not found: %s"
+                % (version_sep, machine_name))
+            split_list = [split_list[0].trim(), '']
+
+        if len(split_list) > 2:
+            logger.warn(
+                "Version separator(%s) is ambiguous: %s"
+                % (version_sep, machine_name))
+            version_parts = machine_name.rpartition(version_sep)
+            split_list = [version_parts[0].trim(), version_parts[2].trim()]
+        return split_list
+
+    def generated_name(self):
+        application = self.application
+        version = self.application_version
+        if not application:
+            raise ValueError("Application is None")
+        if not version:
+            raise ValueError("Version is None")
+        return "%s %s%s" % (
+            application.name,
+            settings.APPLICATION_VERSION_SEPARATOR,
+            version.name),
 
     def is_owner(self, atmo_user):
         return (self.application_version.created_by == atmo_user or

--- a/scripts/admin_update_metadata.py
+++ b/scripts/admin_update_metadata.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+import argparse
+
+from service.openstack import glance_write_machine
+from core.models import ProviderMachine
+
+import django
+django.setup()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--provider", type=int,
+                        help="Atmosphere provider ID"
+                        " to use.")
+    parser.add_argument("image_ids",
+                        help="Image ID(s) to be renamed. (Comma-Separated)")
+    args = parser.parse_args()
+
+    if not args.provider:
+        return parser.print_help()
+
+    all_images = ProviderMachine.objects.filter(
+        instance_source__provider_id=args.provider)
+
+    if args.image_ids:
+        all_images = all_images.filter(
+            instance_source__identifier__in=args.image_ids.split(','))
+
+    for provider_machine in all_images:
+        glance_write_machine(provider_machine)
+        print "Updated metadata for %s" % provider_machine
+
+if __name__ == "__main__":
+    main()

--- a/service/accounts/openstack_manager.py
+++ b/service/accounts/openstack_manager.py
@@ -617,11 +617,17 @@ class AccountDriver(BaseAccountDriver):
     def list_all_instances(self, **kwargs):
         return self.admin_driver.list_all_instances(**kwargs)
 
-    def list_all_images(self, **kwargs):
-        return self.image_manager.list_images(**kwargs)
+    def list_all_images(self, limit_ids=[], **kwargs):
+        all_images = self.image_manager.list_images(**kwargs)
+        if limit_ids:
+            all_images = [
+                img for img in all_images
+                if img.id in limit_ids]
+        return all_images
 
     def list_all_snapshots(self, **kwargs):
-        return [img for img in self.list_all_images(**kwargs) if 'snapshot' in img.get('image_type','image').lower()]
+        return [img for img in self.list_all_images(**kwargs)
+                if 'snapshot' in img.get('image_type', 'image').lower()]
 
     def get_project_by_id(self, project_id):
         return self.user_manager.get_project_by_id(project_id)

--- a/service/openstack.py
+++ b/service/openstack.py
@@ -58,7 +58,6 @@ def glance_write_machine(provider_machine):
         accounts.image_manager.glance.images.update(
             g_image.id, **overrides)
     return True
-    
 
 
 def _make_safe(unsafe_str):
@@ -141,7 +140,7 @@ def glance_update_machine_metadata(provider_machine, metadata={}):
 
 
 
-def glance_update_machine(new_machine):
+def glance_read_machine(new_machine):
     """
     The glance API contains MOAR information about the image then
     a call to 'list_machines()' on the OpenStack (Compute/Nova) Driver.

--- a/service/openstack.py
+++ b/service/openstack.py
@@ -17,9 +17,11 @@ def glance_write_machine(provider_machine):
     base_source = provider_machine.instance_source
     provider = base_source.provider
     base_app = provider_machine.application
+    version = provider_machine.application_version
     identifier = base_source.identifier
     accounts = get_account_driver(provider)
     g_image = glance_image_for(provider.uuid, identifier)
+    app_version_bundle_name = provider_machine.generated_name()
     if not g_image:
         return
     if hasattr(g_image, 'properties'):
@@ -34,23 +36,25 @@ def glance_write_machine(provider_machine):
             " Ask a programmer to fix this!")
     # Do any updating that makes sense... Name. Metadata..
     overrides = {
-        "application_version": str(provider_machine.application_version.name),
+        "application_version": str(version.name),
         "application_uuid": str(base_app.uuid),
         "application_name": _make_safe(base_app.name),
         "application_owner": base_app.created_by.username,
         "application_tags": json.dumps(
             [_make_safe(tag.name) for tag in base_app.tags.all()]),
-        "application_description": _make_safe(base_app.description)
+        "application_description": _make_safe(base_app.description),
+        "version_name": str(version.name),
+        "version_changelog": str(version.change_log)
     }
     if update_method == 'v2':
         extras = {
-            'name': base_app.name,
             'properties': overrides
         }
+        extras['name'] = app_version_bundle_name
         props.update(extras)
         g_image.update(props)
     else:
-        overrides['name'] = base_app.name
+        overrides['name'] = app_version_bundle_name
         accounts.image_manager.glance.images.update(
             g_image.id, **overrides)
     return True
@@ -93,11 +97,11 @@ export OS_IDENTITY_API_VERSION=%s
 def _make_unsafe(safe_str):
     return safe_str.replace("_LINE_BREAK_", "\n")
 
-
 def glance_update_machine_metadata(provider_machine, metadata={}):
     update_method = ""
     base_source = provider_machine.instance_source
     base_app = provider_machine.application
+    version = provider_machine.application_version
     identifier = base_source.identifier
     accounts = get_account_driver(provider)
     g_image = glance_image_for(base_source.provider.uuid, identifier)
@@ -114,13 +118,16 @@ def glance_update_machine_metadata(provider_machine, metadata={}):
             "The method for 'introspecting an image' has changed!"
             " Ask a programmer to fix this!")
     overrides = {
-        "application_version": str(provider_machine.application_version.name),
+        "application_version": str(version.name),
         "application_uuid": base_app.uuid,
         "application_name": _make_safe(base_app.name),
         "application_owner": base_app.created_by.username,
         "application_tags": json.dumps(
             [_make_safe(tag.name) for tag in base_app.tags.all()]),
-        "application_description": _make_safe(base_app.description)}
+        "application_description": _make_safe(base_app.description),
+        "version_name": str(version.name),
+        "version_changelog": str(version.change_log)
+    }
     overrides.update(metadata)
 
     if update_method == 'v2':

--- a/service/tasks/monitoring.py
+++ b/service/tasks/monitoring.py
@@ -225,7 +225,8 @@ def get_public_and_private_apps(provider):
         if any(cloud_machine.name.startswith(prefix) for prefix in ['eri-','eki-', 'ChromoSnapShot']):
             #celery_logger.debug("Skipping cloud machine %s" % cloud_machine)
             continue
-        db_machine = get_or_create_provider_machine(cloud_machine.id, cloud_machine.name, provider.uuid)
+        app_name, version_name = ProviderMachine._split_cloud_name(cloud_machine.name)
+        db_machine = get_or_create_provider_machine(cloud_machine.id, app_name, provider.uuid, version_name=version_name)
         db_version = db_machine.application_version
         db_application = db_version.application
 


### PR DESCRIPTION
Previous versions of glance_write_method would show only `ApplicationName` after multiple versions were created, the machines would become ambiguous:
```
ApplicationName
ApplicationName
ApplicationName
```
New approach would lead to the following:
```
ApplicationName v.1.0
ApplicationName v.2.0
ApplicationName v.final-2.5
```
Additionally, the change log will be included to help aid those who are using the glance API directly in finding the most information about a specific image.

TODO:
- [x] An administration script that will "update" all machines on a provider (registered in Atmosphre) to take the new machine name form. (Optionally, takes a subset of images)
