### PR TITLE
Revert tropo admin url

### DIFF
--- a/core/email.py
+++ b/core/email.py
@@ -509,8 +509,12 @@ def resource_request_email(request, username, quota, reason, options={}):
         member__in=user.group_set.all())
     admin_url = reverse('admin:core_identitymembership_change',
                         args=(membership.id,))
-    if 'admin_url' in options:
-        admin_url = options['admin_url']
+
+    # TODO: To enable joseph's admin_url this will need to be uncommented 
+    # See https://pods.iplantcollaborative.org/jira/browse/ATMO-1155
+    #
+    # if 'admin_url' in options:
+    #     admin_url = options['admin_url']
 
     subject = "Atmosphere Resource Request - %s" % username
     context = {


### PR DESCRIPTION
This reverts the admin url. Now it points to the admin panel for identity memberships.