### PR TITLE
Removed size limit to prevent multiple rotates/day

### DIFF
--- a/extras/logrotate.atmosphere
+++ b/extras/logrotate.atmosphere
@@ -10,7 +10,6 @@
 }
 /opt/dev/atmosphere/logs/libcloud.log {
     daily
-    size 100M
     rotate 10
     missingok
     compress


### PR DESCRIPTION
If size is low, e.g. 100M and the file grows GB/day, it will rotate the log multiple times and could drop logs off the end faster than we wish to do so.  If this configuration is not preferred, we could try to put the size back in, but bump size up to 500M or so.