### PR TITLE
Enable HTTP/2 module in Nginx site configuration

### DIFF
--- a/extras/nginx/site.conf.j2
+++ b/extras/nginx/site.conf.j2
@@ -4,7 +4,7 @@ server {
 }
 
 server {
-    listen   443;
+    listen   443 {% if ENABLE_HTTP2 -%}ssl http2{%- endif %};
 
     server_name {{ SERVER_URL }};
     charset utf-8;

--- a/variables.ini.dist
+++ b/variables.ini.dist
@@ -8,6 +8,7 @@ DJANGO_SERVER_URL = ; https://www.my-website.com
 
 [nginx]
 ATMOSPHERE_PATH = ; /path/to/atmosphere
+ENABLE_HTTP2 = ; True if nginx has http-v2 module; otherwise False
 BUNDLE_FILE = ; selfsigned_bundle.crt
 CERT_DIR = ; /etc/ssl/certs
 CERT_FILE = ; selfsigned_server.crt


### PR DESCRIPTION
Uses a variable, `ENABLE_HTTP2`, within `[nginx]` section to alter the `site.conf` produced. 

See [ATMO-1372](https://pods.iplantcollaborative.org/jira/browse/ATMO-1372)