### PR TITLE
Add warning hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ your code passes all the tests.
 ln -s contrib/pre-push.hook .git/hooks/pre-push
 ```
 
+When master is pulled, it's helpful to know if a `pip install` or a `manage.py
+migrate` is necessary. To get a helpful warning:
+```bash
+ln -s contrib/post-merge.hook .git/hooks/post-merge
+ln -s contrib/migrations-warning.rb .git/hooks/migrations-warning.rb
+ln -s contrib/requirements-warning.rb .git/hooks/requirements-warning.rb
+```
+
 ### Coding Conventions
 
 #### Import ordering

--- a/contrib/migrations-warning.rb
+++ b/contrib/migrations-warning.rb
@@ -1,0 +1,26 @@
+DEBUG = false
+# Get the commits before the merge
+#   ex. heads = ["<latest commit of master>", "<previous commit of master>", ...]
+heads = `git reflog -n 2 | awk '{ print $1 }'`.split
+
+# Make sure our revision history has at least 2 entries
+if heads.length < 2
+    exit 0 
+end
+
+# List the file names before and after merge that contain migrations 
+#   ex. files = ['core/migrations/blahbal.py']                       
+
+files = `git diff --name-only #{heads[1]} #{heads[0]} | grep migrations/`
+if /migrations/.match files then
+   default = "\e[0m"
+   red = "\e[31m" 
+   puts "[#{red}migrations-warning.rb hook#{default}]: New migrations found."
+
+   if DEBUG
+       puts "Files found:"
+       puts files
+   end
+
+   puts "./manage.py migrate"
+end

--- a/contrib/post-merge.hook
+++ b/contrib/post-merge.hook
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Warn when requirements.txt changes
+if [ -e .git/hooks/requirements-warning.rb ]; then
+    ruby .git/hooks/requirements-warning.rb;
+fi
+
+# Warn when a pull includes new migration files
+if [ -e .git/hooks/migrations-warning.rb ]; then
+    ruby .git/hooks/migrations-warning.rb; 
+fi

--- a/contrib/requirements-warning.rb
+++ b/contrib/requirements-warning.rb
@@ -1,0 +1,24 @@
+DEBUG = false
+
+# Get the commits before the merge
+#   ex. heads = ["<latest commit of master>", "<previous commit of master>", ...]
+heads = `git reflog -n 2 | awk '{ print $1 }'`.split
+
+# Make sure our revision history has at least 2 entries
+if heads.length < 2
+    exit 0 
+end
+
+files = `git diff --name-only #{heads[1]} #{heads[0]} | grep requirements.txt`
+diffFiles = `git diff --name-only #{heads[1]} #{heads[0]} | grep requirements.txt | tr "\n" " "`
+if diffFiles then
+    default = "\e[0m"
+    red = "\e[31m" 
+    puts "[#{red}requirements-warning.rb hook#{default}]: New python requirements."
+    puts "pip install #{diffFiles}"
+
+    if DEBUG then
+        # Print the diff with 0 lines of context
+        puts `git diff -U0 #{heads[1]} #{heads[0]} -- #{diffFiles}`
+    end
+end


### PR DESCRIPTION
This includes some hooks that are run when the user pulls from master (more
specifically any merge). They comment when there are changes made to
requirements.txt or when migration files are added.

For example:

    [requirements-warning.rb hook]: New python requirements.
    pip install dev_requirements.txt requirements.txt
    [migrations-warning.rb hook]: New migrations found.
    ./manage.py migrate