### PR TITLE
Atmo 1369 assign project on v2 create volume

### DIFF
--- a/api/v1/views/volume.py
+++ b/api/v1/views/volume.py
@@ -23,7 +23,7 @@ from core.models.instance_source import InstanceSource
 from core.models.group import IdentityMembership
 
 from service.driver import prepare_driver
-from service.volume import create_volume,\
+from service.volume import create_esh_volume,\
     create_bootable_volume,\
     _update_volume_metadata
 from service.exceptions import OverQuotaError
@@ -140,7 +140,7 @@ class VolumeSnapshot(AuthAPIView):
                     "Snapshot not created. Process aborted.")
         # STEP 2 - Create volume from snapshot
         try:
-            success, esh_volume = create_volume(esh_driver, identity_uuid,
+            success, esh_volume = create_esh_volume(esh_driver, identity_uuid,
                                                 display_name, size,
                                                 description, metadata,
                                                 snapshot=snapshot)
@@ -312,7 +312,7 @@ class VolumeList(AuthAPIView):
         else:
             snapshot = None
         try:
-            success, esh_volume = create_volume(driver, user.username, identity_uuid,
+            success, esh_volume = create_esh_volume(driver, user.username, identity_uuid,
                                                 name, size, description,
                                                 snapshot=snapshot, image=image)
         except OverQuotaError as oqe:

--- a/api/v2/serializers/details/volume.py
+++ b/api/v2/serializers/details/volume.py
@@ -29,10 +29,6 @@ class VolumeSerializer(serializers.HyperlinkedModelSerializer):
                                  read_only=True)
 
     projects = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
-    snapshot_id = serializers.CharField(write_only=True, allow_blank=True,
-                                        required=False)
-    image_id = serializers.CharField(write_only=True, allow_blank=True,
-                                     required=False)
     uuid = serializers.CharField(source='instance_source.identifier',
                                  read_only=True)
     # NOTE: this is still using ID instead of UUID -- due to abstract classes and use of getattr in L271 of rest_framework/relations.py, this is a 'kink' that has not been worked out yet.
@@ -55,50 +51,15 @@ class VolumeSerializer(serializers.HyperlinkedModelSerializer):
             'projects',
             'size',
             'url',
-
-            'snapshot_id',
-            'image_id',
-
             'start_date',
             'end_date')
 
     def validate(self, data):
-        image_id = data.get('image')
-        snapshot_id = data.get('snapshot')
-
-        #: Only allow one at a time
-        if snapshot_id and image_id:
-            raise serializers.ValidationError(
-                "Use either `snapshot_id` or `image_id` not both.")
-        return data
-
-    def create(self, validated_data):
-        name = validated_data.get('name')
-        size = validated_data.get('size')
-        identifier = validated_data.get("identifier")
-        description = validated_data.get('description')
-        user = validated_data.get("user")
-        start_date = validated_data.get("created_on")
-
-        instance_source = validated_data.get("instance_source")
-        identity = instance_source.get("created_by_identity")
-        provider = identity.provider
-
-        source = InstanceSource.objects.create(
-            identifier=identifier,
-            provider=provider,
-            created_by=user,
-            created_by_identity=identity)
-
-        kwargs = {
-            "name": name,
-            "size": size,
-            "description": description,
-            "instance_source": source,
-            "start_date": start_date
-        }
-
-        return Volume.objects.create(**kwargs)
+        if not data and not self.initial_data:
+            return data
+        raise Exception(
+            "This serializer for GET output ONLY! -- "
+            "Use the POST or UPDATE serializers instead!")
 
 
 class UpdateVolumeSerializer(serializers.ModelSerializer):

--- a/api/v2/serializers/post/__init__.py
+++ b/api/v2/serializers/post/__init__.py
@@ -1,7 +1,9 @@
 from .instance import InstanceSerializer
+from .volume import VolumeSerializer
 
 
 __all__ = (
     "InstanceSerializer",
+    "VolumeSerializer",
 )
 

--- a/api/v2/serializers/post/volume.py
+++ b/api/v2/serializers/post/volume.py
@@ -1,0 +1,87 @@
+from core.models import (
+    InstanceSource, Volume, Identity, Project)
+from rest_framework import serializers
+
+
+class VolumeSerializer(serializers.ModelSerializer):
+    """
+    This serializer should only be used for Volume Creation.
+    This serializer should *never* be returned to the user.
+    Instances created from this serializer should be
+    re-serialized with a GET/Details Serializer.
+    """
+    identity = serializers.SlugRelatedField(
+        source='created_by_identity', slug_field='uuid',
+        queryset=Identity.objects.all())
+    name = serializers.CharField()
+    project = serializers.SlugRelatedField(
+        source="projects", slug_field="uuid", queryset=Project.objects.all(),
+        required=False, allow_null=True)
+    snapshot_id = serializers.CharField(write_only=True, allow_blank=True,
+                                        required=False)
+    image_id = serializers.CharField(write_only=True, allow_blank=True,
+                                     required=False)
+
+    def create(self, validated_data):
+        name = validated_data.get('name')
+        size = validated_data.get('size')
+        identifier = validated_data.get("identifier")
+        description = validated_data.get('description')
+        user = validated_data.get("user")
+        start_date = validated_data.get("created_on")
+        instance_source = validated_data.get("instance_source")
+        identity = instance_source.get("created_by_identity")
+        provider = identity.provider
+
+        source = InstanceSource.objects.create(
+            identifier=identifier,
+            provider=provider,
+            created_by=user,
+            created_by_identity=identity)
+
+        kwargs = {
+            "name": name,
+            "size": size,
+            "description": description,
+            "instance_source": source,
+            "start_date": start_date
+        }
+
+        return Volume.objects.create(**kwargs)
+
+    def is_valid(self, raise_exception=False):
+        data = self.initial_data
+        project = data.get('project')
+        if type(project) == int:
+            if raise_exception:
+                raise serializers.ValidationError(
+                    "The 'project' argument (%s) should be a UUID, not an Int."
+                    % project)
+            return False
+        return super(VolumeSerializer, self).is_valid(
+            raise_exception=raise_exception)
+
+    def validate(self, data):
+        image_id = data.get('image_id')
+        snapshot_id = data.get('snapshot_id')
+
+        #: Only allow one at a time
+        if snapshot_id and image_id:
+            raise serializers.ValidationError(
+                "Use either `snapshot_id` or `image_id` not both.")
+        return data
+
+    class Meta:
+        model = Volume
+        fields = (
+            # Required
+            'description',
+            'identity',
+            'name',
+            'size',
+            # Optional
+            'project',
+            # Optional + one or the other
+            'image_id',
+            'snapshot_id',
+        )

--- a/core/models/project.py
+++ b/core/models/project.py
@@ -27,8 +27,10 @@ class Project(models.Model):
     owner = models.ForeignKey(Group, related_name="projects")
     applications = models.ManyToManyField(Application, related_name="projects",
                                           blank=True)
+    # FIXME: Instances + Volumes are *NOT* MANYTOMANY
     instances = models.ManyToManyField(Instance, related_name="projects",
                                        blank=True)
+    # FIXME: Instances + Volumes are *NOT* MANYTOMANY
     volumes = models.ManyToManyField(Volume, related_name="projects",
                                      blank=True)
     links = models.ManyToManyField(ExternalLink, related_name="projects",

--- a/core/models/volume.py
+++ b/core/models/volume.py
@@ -26,6 +26,7 @@ class Volume(BaseSource):
     size = models.IntegerField()
     name = models.CharField(max_length=256)
     description = models.TextField(blank=True, null=True)
+
     objects = models.Manager()  # The default manager.
     active_volumes = ActiveVolumesManager()
 


### PR DESCRIPTION
[x] - Updated the `create_volume_or_fail` method to return a core object
rather than a cloud object.
[x] - Update v1 API to call `create_esh_volume`
[x] - v2 API serializer now has a POST Serializer, and swaps serializers
before returning the value.
[x] - Project appends volume at the end, it cannot be added in the save()
method.