### PR TITLE
Update uWSGI dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ python-logstash==0.4.5
 #Theirs
 psycopg2==2.5.4
 python-ldap==2.4.19
-uWSGI==2.0.9
+uWSGI==2.0.13
 
 ## ours
 chromogenic==0.2.4


### PR DESCRIPTION
Relates to feedback from [Clank Issue 63](https://github.com/iPlantCollaborativeOpenSource/clank/issues/63) where the uWSGI 2.0.9 on Ubuntu 16.04 encounters a compile on `pip install`. 

This will require verification in the `dev` environment. A merge into dev can be verified using the QA regression tests, both API & QA. 
