### PR TITLE
Updated Django template backend definitions

### DIFF
--- a/atmosphere/settings/__init__.py
+++ b/atmosphere/settings/__init__.py
@@ -19,7 +19,6 @@ from kombu import Exchange, Queue
 
 # Debug Mode
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 
 # Enforcing mode -- True, when in production (Debug=False)
 ENFORCING = not DEBUG
@@ -149,8 +148,10 @@ TEMPLATES = [
             os.path.join(PROJECT_ROOT, 'templates'),
         ],
         'APP_DIRS': True,
-        'OPTIONS': { 'context_processors':
-            [ # Insert your TEMPLATE_CONTEXT_PROCESSORS here or use this # list if you haven't customized them:
+        'OPTIONS': {
+            'context_processors': [
+                # Insert your TEMPLATE_CONTEXT_PROCESSORS here or use this
+                # list if you haven't customized them:
                 'django.contrib.auth.context_processors.auth',
                 'django.template.context_processors.debug',
                 'django.template.context_processors.i18n',
@@ -159,6 +160,7 @@ TEMPLATES = [
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',
             ],
+            'debug': False
         },
     },
 ]

--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -13,7 +13,16 @@ globals().update(vars(sys.modules['atmosphere.settings']))
 
 # Debug Mode
 DEBUG = {{ DJANGO_DEBUG }}
-TEMPLATE_DEBUG = {{ DJANGO_TEMPLATE_DEBUG }}
+
+{% if DJANGO_TEMPLATE_DEBUG -%}
+template_backends = filter(lambda t:
+    t['BACKEND'] == 'django.template.backends.django.DjangoTemplates',
+    TEMPLATES)
+for backend in template_backends:
+    if 'debug' in backend['OPTIONS']:
+        backend['OPTIONS']['debug'] = {{ DJANGO_TEMPLATE_DEBUG }}
+{%- endif %}
+
 {% if ENFORCING %}
 ENFORCING = True
 {% else %}


### PR DESCRIPTION
When upgrading from Django 1.8 to 1.9, there were [changes to the definition of settings.TEMPLATES](https://docs.djangoproject.com/en/1.9/ref/templates/upgrading/). The presence of `TEMPLATE_DEBUG` will cause a warning to generated (this will happen in atmosphere upon `service atmosphere start`). A similar PR was submitted to troposphere (as [Troposphere PR 403](https://github.com/iPlantCollaborativeOpenSource/troposphere/pull/403)).

The warning message can be produced by doing a `check`:
```
09:59 $ ./manage.py check 
System check identified some issues:

WARNINGS:
?: (1_8.W001) The standalone TEMPLATE_* settings were deprecated in Django 1.8 and the TEMPLATES dictionary takes precedence. You must put the values of the following settings into your default TEMPLATES dict: TEMPLATE_DEBUG.
```

The definition in atmosphere was altered to account for multiple backends present in `settings.TEMPLATES`. 

An example of the change being set in the `'OPTIONS'` of the Django backend, but not in the Jinja2 backend:
```
09:19 $ ./manage.py shell
....
In [1]: from atmosphere.settings import TEMPLATES

In [2]: TEMPLATES
Out[2]: 
[{'BACKEND': 'django.template.backends.jinja2.Jinja2',
  'DIRS': ['/Users/lenards/devel/atmosphere/core/templates/core/email']},
 {'APP_DIRS': True,
  'BACKEND': 'django.template.backends.django.DjangoTemplates',
  'DIRS': ['/Users/lenards/devel/atmosphere/templates'],
  'OPTIONS': {'context_processors': ['django.contrib.auth.context_processors.auth',
    'django.template.context_processors.debug',
    'django.template.context_processors.i18n',
    'django.template.context_processors.media',
    'django.template.context_processors.static',
    'django.template.context_processors.tz',
    'django.contrib.messages.context_processors.messages'],
   'debug': True}}]
```

### DJANGO_TEMPLATE_DEBUG = False, atmosphere/settings/local.py
```python
SECRETS_MODULE = secrets

globals().update(vars(sys.modules['atmosphere.settings']))

# Debug Mode
DEBUG = True




ENFORCING = False
```

