### PR TITLE
Fixes lamba validators in add_new_provider.py

### DIFF
--- a/scripts/add_new_provider.py
+++ b/scripts/add_new_provider.py
@@ -170,7 +170,7 @@ def get_provider_info(provider_info={}):
     if not provider_info.get('platform'):
         print "Select a platform type for your new provider"
         print "1: KVM, 2: Xen"
-        platform = require_input("Select a platform type (1/2): ", lambda answer: answer in ['1','2'])
+        platform = require_input("Select a platform type (1/2): ", lambda answer: answer if answer in ['1','2'] else None)
         if platform == '1':
             platform = KVM
         elif platform == '2':
@@ -230,7 +230,7 @@ def get_provider_credentials(credential_info={}):
 
     if not credential_info.get('ex_force_auth_version'):
         print "What is the Authentication Scheme (Openstack ONLY -- Default:'2.0_password')?"
-        ex_force_auth_version = require_input("ex_force_auth_version for the provider: ", lambda answer: answer in ['2.0_password','3.x_password'])
+        ex_force_auth_version = require_input("ex_force_auth_version for the provider: ", lambda answer: answer if answer in ['2.0_password','3.x_password'] else None)
         credential_info['ex_force_auth_version'] = ex_force_auth_version
 
     return credential_info


### PR DESCRIPTION
Since 0241751155e8d5269a2c188ff4b54435bc0aa5f6, the return of validate_answer is expected to be a validated answer (not simply `True`/`False`). This change updates the lambdas to meet that expectation.

Otherwise, adding a provider fails by setting validated values like Provider.virtualization to `True`:

```
Traceback (most recent call last):
  File "./scripts/add_new_provider.py", line 356, in <module>
    main()
  File "./scripts/add_new_provider.py", line 350, in main
    new_provider = create_provider(provider_info)
  File "./scripts/add_new_provider.py", line 296, in create_provider
    type=provider_info["type"], public=False)
  File "/opt/env/atmo/local/lib/python2.7/site-packages/django/db/models/manager.py", line 127, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/opt/env/atmo/local/lib/python2.7/site-packages/django/db/models/query.py", line 346, in create
    obj = self.model(**kwargs)
  File "/opt/env/atmo/local/lib/python2.7/site-packages/django/db/models/base.py", line 468, in __init__
    setattr(self, field.name, rel_obj)
  File "/opt/env/atmo/local/lib/python2.7/site-packages/django/db/models/fields/related.py", line 639, in __set__
    self.field.rel.to._meta.object_name,
ValueError: Cannot assign "True": "Provider.virtualization" must be a "PlatformType" instance.
```