### PR TITLE
Fix templates for support to allow quotes, brackets, etc.

### DIFF
--- a/core/templates/core/email/feedback.html
+++ b/core/templates/core/email/feedback.html
@@ -1,6 +1,6 @@
-Username : {{ username }} ({{ name }})
+Username : {{ username }} ({{ name|safe }})
 
-Feedback : {{ feedback }}
+Feedback : {{ feedback|safe }}
 
 Provider : {{ provider }}
 
@@ -10,16 +10,16 @@ Server : {{ server }}
 
 Instances :
 {% for i in instances %}
-    Name : {{ i.name }}
-    ID : {{ i.provider_alias }}
+    Name : {{ i.name|safe }}
+    UUID : {{ i.provider_alias }}
     Image : {{ i.provider_machine.identifier }}
     IP : {{ i.ip_address }}
 {% endfor %}
 
 Volumes :
 {% for v in volumes %}
-    Name : {{ v.name }}
-    ID : {{ v.identifier }}
+    Name : {{ v.name|safe }}
+    UUID : {{ v.identifier }}
     Size : {{ v.size }}
 {% endfor %}
 

--- a/core/templates/core/email/instance_report.html
+++ b/core/templates/core/email/instance_report.html
@@ -1,13 +1,13 @@
-Username : {{ username }} ({{ name }})
+Username : {{ username }} ({{ name|safe }})
 {% if problems %}
 Problems : 
-    {{ problems|join("\n")|indent(4, false) }}
+    {{ problems|join("\n")|indent(4, false)|safe }}
 {% endif %}
 Details : 
-    {{ message }}
+    {{ message|safe }}
 
 Instance :
-    Name : {{ instance.name }}
+    Name : {{ instance.name|safe }}
     {%- if status %}
     Status : {{ status.status }} since {{ status.start_date.date() }}
     {% endif -%}

--- a/core/templates/core/email/volume_report.html
+++ b/core/templates/core/email/volume_report.html
@@ -1,14 +1,14 @@
-Username : {{ username }} ({{ name }})
+Username : {{ username }} ({{ name|safe }})
 {% if problems %}
 Problems : 
-    {{ problems|join("\n")|indent(4, false) }}
+    {{ problems|join("\n")|indent(4, false)|safe }}
 {% endif %}
 Details : 
-    {{ message }}
+    {{ message|safe }}
 
 Volume :
-    Name : {{ volume.name }}
-    ID : {{ volume.id }}
+    Name : {{ volume.name|safe }}
+    UUID : {{ volume.identifier }}
     Size : {{ volume.size }} GB
 
 Provider : {{ provider }}


### PR DESCRIPTION
TLDR: let the email ticket system be responsible for sanitizing support emails

By default django auto-escapes all templates. You have to mark something as
safe for it to be not escaped. Our issue is that django was escaping html,
and then RT escaped the escaped content!