### PR TITLE
Resolved import failures for tests

### DIFF
--- a/allocation/tests.py
+++ b/allocation/tests.py
@@ -18,8 +18,9 @@ from dateutil.relativedelta import relativedelta
 import pytz
 
 from django.test import TestCase
-from django.utils import unittest
 from django.utils.timezone import datetime, timedelta
+
+import unittest
 
 from allocation import engine, validate_interval
 from allocation.models import Provider, Machine, Size, Instance,\

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -1,6 +1,5 @@
 from django.core.urlresolvers import reverse
 from django.test import TestCase
-from django.utils import unittest
 
 import json
 

--- a/core/tests/instance.py
+++ b/core/tests/instance.py
@@ -1,6 +1,7 @@
 from django.core.urlresolvers import reverse
 from django.test import TestCase
-from django.utils import unittest
+
+import unittest
 
 from dateutil.relativedelta import relativedelta
 from django.utils.timezone import datetime

--- a/core/tests/machine_request.py
+++ b/core/tests/machine_request.py
@@ -1,9 +1,13 @@
-from django.test import TestCase
-from django.utils import unittest
-from uuid import uuid4
 from dateutil.relativedelta import relativedelta
-from django.utils.timezone import datetime
+from uuid import uuid4
+
+import unittest
+
 import pytz
+
+from django.test import TestCase
+from django.utils.timezone import datetime
+
 from core.tests.helpers import CoreProviderMachineHelper, CoreMachineRequestHelper, CoreInstanceHelper
 from service.machine import process_machine_request
 


### PR DESCRIPTION
This resolves an import failure generated while attempting to run unit tests. 

## Background

In Django 1.9, [`django.utils.unittest` was removed](http://django.readthedocs.io/en/latest/internals/deprecation.html#deprecation-removed-in-1-9).

The deprecation announcement in Django provided some context on how to handle the situation:
> `django.utils.unittest` provided uniform access to the `unittest2` library on all Python 
> versions. Since `unittest2` became the standard library’s `unittest` module in Python 
> 2.7, and Django 1.7 drops support for older Python versions, this module isn’t useful 
> anymore. It has been deprecated. Use `unittest` instead.

source: http://django.readthedocs.io/en/latest/releases/1.7.html#django-utils-unittest

I've made 4 changes and opted for continuing to use `unittest` as the subclass for 4 `TestCase` definitions.

## Clean Execution Locally

```
(env) ✔ ~/devel/atmosphere [skip-test-failures L|●4…3] 
17:34 $ ./manage.py test
Creating test database for alias 'default'...
 ...
This can take a while...
Created 0 machines - 0:00:00.001512
Updated 0 machine_requests - 0:00:00.001299
Created 0 Volumes 0:00:00.000845
Updated 0 Instances 0:00:00.000973
Completed!
..............................................................................s.s..........
----------------------------------------------------------------------
Ran 91 tests in 1.570s

OK (skipped=2)
Converted 0 ProviderMachines into 0 ApplicationVersions on 0 applications Destroying test database for alias 'default'...```