### PR TITLE
Create a setting to blacklist tags

### DIFF
--- a/api/v2/serializers/details/tag.py
+++ b/api/v2/serializers/details/tag.py
@@ -14,10 +14,14 @@ class TagSerializer(serializers.HyperlinkedModelSerializer):
     )
     allow_access = serializers.SerializerMethodField()
 
+    def _get_request_user(self):
+        if 'request' not in self.context:
+            raise ValueError("Expected 'request' context for this serializer")
+        return self.context['request'].user
+
     def get_allow_access(self, tag):
-        tag_name = tag.name.lower()
-        return any(tag_name == black_tag.lower()
-                   for black_tag in BLACKLIST_TAGS)
+        user = self._get_request_user()
+        return tag.allow_access(user)
 
     class Meta:
         model = Tag

--- a/api/v2/serializers/details/tag.py
+++ b/api/v2/serializers/details/tag.py
@@ -1,7 +1,10 @@
-from core.models import Tag
 from rest_framework import serializers
+
+from atmosphere.settings import BLACKLIST_TAGS
+
 from api.v2.serializers.summaries import UserSummarySerializer
 from api.v2.serializers.fields.base import UUIDHyperlinkedIdentityField
+from core.models import Tag
 
 
 class TagSerializer(serializers.HyperlinkedModelSerializer):
@@ -9,6 +12,15 @@ class TagSerializer(serializers.HyperlinkedModelSerializer):
     url = UUIDHyperlinkedIdentityField(
         view_name='api:v2:tag-detail',
     )
+    allow_access = serializers.SerializerMethodField()
+
+    def get_allow_access(self, tag):
+        tag_name = tag.name.lower()
+        return any(tag_name == black_tag.lower()
+                   for black_tag in BLACKLIST_TAGS)
+
     class Meta:
         model = Tag
-        fields = ('id', 'uuid', 'url', 'name', 'description', 'user')
+        fields = (
+            'id', 'uuid', 'url', 'name',
+            'description', 'user', 'allow_access')

--- a/api/v2/serializers/summaries/tag.py
+++ b/api/v2/serializers/summaries/tag.py
@@ -1,7 +1,5 @@
 from rest_framework import serializers
 
-from atmosphere.settings import BLACKLIST_TAGS
-
 from api.v2.serializers.fields.base import UUIDHyperlinkedIdentityField
 from core.models import Tag
 
@@ -18,13 +16,8 @@ class TagSummarySerializer(serializers.HyperlinkedModelSerializer):
         return self.context['request'].user
 
     def get_allow_access(self, tag):
-        tag_name = tag.name.lower()
         user = self._get_request_user()
-        if user and (user.is_staff or user.is_superuser):
-            return True
-        in_black_list = any(tag_name == black_tag.lower()
-                            for black_tag in BLACKLIST_TAGS)
-        return not in_black_list
+        return tag.allow_access(user)
 
     class Meta:
         model = Tag

--- a/api/v2/serializers/summaries/tag.py
+++ b/api/v2/serializers/summaries/tag.py
@@ -1,12 +1,31 @@
-from core.models import Tag
 from rest_framework import serializers
+
+from atmosphere.settings import BLACKLIST_TAGS
+
 from api.v2.serializers.fields.base import UUIDHyperlinkedIdentityField
+from core.models import Tag
 
 
 class TagSummarySerializer(serializers.HyperlinkedModelSerializer):
     url = UUIDHyperlinkedIdentityField(
         view_name='api:v2:tag-detail',
     )
+    allow_access = serializers.SerializerMethodField()
+
+    def _get_request_user(self):
+        if 'request' not in self.context:
+            raise ValueError("Expected 'request' context for this serializer")
+        return self.context['request'].user
+
+    def get_allow_access(self, tag):
+        tag_name = tag.name.lower()
+        user = self._get_request_user()
+        if user and (user.is_staff or user.is_superuser):
+            return True
+        in_black_list = any(tag_name == black_tag.lower()
+                            for black_tag in BLACKLIST_TAGS)
+        return not in_black_list
+
     class Meta:
         model = Tag
-        fields = ('id', 'uuid', 'url', 'name', 'description')
+        fields = ('id', 'uuid', 'url', 'name', 'description', 'allow_access')

--- a/api/v2/views/machine_request.py
+++ b/api/v2/views/machine_request.py
@@ -35,6 +35,7 @@ class MachineRequestViewSet(BaseRequestViewSet):
     ordering = ('-start_date',)
 
     def get_queryset(self):
+        request_user = self.request.user
         if 'active' in self.request.query_params:
             all_active = MachineRequest.objects.filter(
                 (

--- a/atmosphere/settings/__init__.py
+++ b/atmosphere/settings/__init__.py
@@ -24,6 +24,7 @@ DEBUG = True
 ENFORCING = not DEBUG
 
 USE_ALLOCATION_SOURCE = False
+BLACKLIST_TAGS = ["Featured",]
 
 SETTINGS_ROOT = os.path.abspath(os.path.dirname(__file__))
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__),

--- a/core/models/tag.py
+++ b/core/models/tag.py
@@ -2,6 +2,8 @@
   Service Tag models for Atmosphere.
 """
 
+from atmosphere.settings import BLACKLIST_TAGS
+
 from django.db import models
 import uuid
 
@@ -11,6 +13,14 @@ class Tag(models.Model):
     description = models.CharField(max_length=1024)
     # Not-Null="User-Specific"
     user = models.ForeignKey('AtmosphereUser', null=True, blank=True)
+
+    def allow_access(self, user):
+        tag_name = self.name.lower()
+        if user and (user.is_staff or user.is_superuser):
+            return True
+        in_black_list = any(tag_name == black_tag.lower()
+                            for black_tag in BLACKLIST_TAGS)
+        return not in_black_list
 
     def in_use(self):
         if self.application_set.count() != 0:

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -29,14 +29,10 @@ class AtmosphereUser(AbstractUser):
 
     def is_valid(self):
         """
-        FIXME: How do we make this 'pluggable'?
+        FIXME: Don't keep this. Find the *REAL* is_valid.
 
         """
-        # FIXME: This code fixed in a future PR. Ignore this.
-        if 'jetstream' in settings.INSTALLED_APPS:
-            return self._jetstream_valid()
-        else:
-            return self._iplant_valid()
+        return True
 
     def _jetstream_valid(self):
         """


### PR DESCRIPTION
Rather than introduce more database migrations, this is a simple approach that will allow the Troposphere UI to block users from submitting tags that are reserved for staff users *only*.

- [x] Allow Troposphere to provide user with a clean list ahead of time.
- [x] Create a new 'field' for the Tag API endpoint (allow_access) that is True if that user can add the tag to their image.
- [x] Atmosphere should also filter and remove tags that are in the BLACKLIST_TAGS passed directly to the MachineRequest API.

[Depends-on-Troposphere PR](https://github.com/iPlantCollaborativeOpenSource/troposphere/pull/435)