### PR TITLE
Enforce allocation sources

### DIFF
--- a/atmosphere/settings/__init__.py
+++ b/atmosphere/settings/__init__.py
@@ -20,8 +20,8 @@ from kombu import Exchange, Queue
 # Debug Mode
 DEBUG = True
 
-# Enforcing mode -- True, when in production (Debug=False)
-ENFORCING = not DEBUG
+# Enforcing mode -- False, unless set otherwise. (ONLY ONE Production server should be set to 'ENFORCING'.)
+ENFORCING = False
 
 USE_ALLOCATION_SOURCE = False
 BLACKLIST_TAGS = ["Featured",]
@@ -485,11 +485,11 @@ CELERYBEAT_SCHEDULE = {
         "schedule": timedelta(minutes=30),
         "options": {"expires": 10 * 60, "time_limit": 10 * 60}
     },
-    "monitor_instance_allocations": {
-        "task": "monitor_instance_allocations",
-        "schedule": timedelta(minutes=15),
-        "options": {"expires": 25 * 60, "time_limit": 25 * 60}
-    },
+    # "monitor_instance_allocations": {
+    #     "task": "monitor_instance_allocations",
+    #     "schedule": timedelta(minutes=15),
+    #     "options": {"expires": 25 * 60, "time_limit": 25 * 60}
+    # },
     "monitor_instances": {
         "task": "monitor_instances",
         "schedule": timedelta(minutes=15),

--- a/core/hooks/allocation_source.py
+++ b/core/hooks/allocation_source.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 
 from threepio import logger
-
 from core.models import (
     AllocationSource, Instance, AtmosphereUser,
     UserAllocationSnapshot,
@@ -10,6 +9,57 @@ from core.models import (
 
 
 # Pre-Save hooks
+
+# Post-Save hooks
+def listen_for_allocation_overage(sender, instance, raw, **kwargs):
+    """
+    This listener expects:
+    EventType - 'allocation_source_snapshot'
+    EventPayload - {
+        "allocation_source_id": "37623",
+        "compute_used":100.00,  # 100 hours used ( a number, not a string, IN HOURS!)
+        "global_burn_rate":2.00,  # 2 hours used each hour
+    }
+    The method will only run in the case where an allocation_source `compute_used` >= source.compute_allowed
+    """
+
+    event = instance
+    if event.name != 'allocation_source_snapshot':
+        return None
+    # Circular dep...
+    from core.models import EventTable
+    from service.tasks.monitoring import enforce_allocation_overage
+    payload = event.payload
+    allocation_source_id = payload['allocation_source_id']
+    new_compute_used = payload['compute_used']
+    source = AllocationSource.objects.filter(source_id=allocation_source_id).first()
+    current_percentage = int(100.0*new_compute_used/source.compute_allowed)
+    if new_compute_used == 0:
+        return
+    if not source:
+        return
+    if not source.compute_allowed:
+        return
+    if new_compute_used < source.compute_allowed:
+        return
+    # FIXME: test for previous event of 'allocation_source_threshold_enforced'
+    prev_enforcement_event = EventTable.objects\
+        .filter(name="allocation_source_threshold_enforced")\
+        .filter(entity_id=allocation_source_id).last()
+    if prev_enforcement_event:
+        return
+    enforce_allocation_overage.apply_async(args=source.source_id)
+    new_payload = {
+        "allocation_source_id": source.source_id,
+        "actual_value": current_percentage
+    }
+    EventTable.create_event(
+        name="allocation_source_threshold_enforced",
+        entity_id=source.source_id,
+        payload=new_payload)
+    return
+
+
 def listen_before_allocation_snapshot_changes(sender, instance, raw, **kwargs):
     """
     This listener expects:
@@ -78,7 +128,6 @@ def listen_before_allocation_snapshot_changes(sender, instance, raw, **kwargs):
     return
 
 
-# Post-Save hooks
 def listen_for_allocation_threshold_met(sender, instance, created, **kwargs):
     """
     This listener expects:

--- a/core/models/allocation_source.py
+++ b/core/models/allocation_source.py
@@ -14,6 +14,16 @@ class AllocationSource(models.Model):
         source_ids = UserAllocationSource.objects.filter(user=user).values_list('allocation_source', flat=True)
         return AllocationSource.objects.filter(id__in=source_ids)
 
+    @property
+    def all_users(self):
+        """
+        Using the UserAllocationSource join-table, return a list of all (known) users.
+        """
+        from core.models import AtmosphereUser
+        user_ids = self.users.values_list('user', flat=True)
+        user_qry = AtmosphereUser.objects.filter(id__in=user_ids)
+        return user_qry
+
     def __unicode__(self):
         return "%s (ID:%s, Compute Allowed:%s)" %\
             (self.name, self.source_id,

--- a/core/models/event_table.py
+++ b/core/models/event_table.py
@@ -13,6 +13,7 @@ from core.hooks.allocation_source import (
     listen_for_allocation_snapshot_changes,
     listen_for_user_snapshot_changes,
     listen_for_allocation_threshold_met,
+    listen_for_allocation_overage,
     listen_for_instance_allocation_changes
 )
 
@@ -55,7 +56,8 @@ def listen_for_changes(sender, instance, created, **kwargs):
     return None
 
 # Instantiate the hooks:
-pre_save.connect(listen_before_allocation_snapshot_changes, sender=EventTable)
+post_save.connect(listen_before_allocation_snapshot_changes, sender=EventTable)
+post_save.connect(listen_for_allocation_overage, sender=EventTable)
 #post_save.connect(listen_for_changes, sender=EventTable)
 post_save.connect(listen_for_allocation_threshold_met, sender=EventTable)
 post_save.connect(listen_for_instance_allocation_changes, sender=EventTable)

--- a/service/monitoring.py
+++ b/service/monitoring.py
@@ -10,6 +10,7 @@ from core.models import AtmosphereUser as User
 from core.models import AccountProvider
 from core.models.allocation_strategy import Allocation as CoreAllocation
 from core.models.allocation_strategy import AllocationStrategy as CoreAllocationStrategy
+from core.models.allocation_strategy import InstanceAllocationSourceSnapshot
 from core.models.credential import Credential
 from core.models import IdentityMembership, Identity, InstanceStatusHistory
 from core.models.instance import Instance as CoreInstance
@@ -263,35 +264,7 @@ def provider_over_allocation_enforcement(identity, user):
     # TODO: Parallelize this operation so you don't wait for larger instances
     # to finish 'wait_for' task below..
     for instance in esh_instances:
-        try:
-            if driver._is_active_instance(instance):
-                # Suspend active instances, update the task in the DB
-                # NOTE: identity.created_by COULD BE the Admin User, indicating that this action/InstanceHistory was
-                #       executed by the administrator.. Future Release Idea.
-                _execute_provider_action(
-                    identity,
-                    identity.created_by,
-                    instance,
-                    action.name)
-                # NOTE: Intentionally added to allow time for
-                #      the Cloud to begin 'suspend' operation
-                #      before querying for the instance again.
-                # TODO: Instead: Add "wait_for" change from active to any
-                # terminal, non-active state?
-                wait_time = random.uniform(2, 6)
-                time.sleep(wait_time)
-                updated_esh = driver.get_instance(instance.id)
-                convert_esh_instance(
-                    driver, updated_esh,
-                    identity.provider.uuid,
-                    identity.uuid,
-                    user)
-        except Exception as e:
-            # Raise ANY exception that doesn't say
-            # 'This instance is already in the requested VM state'
-            # NOTE: This is OpenStack specific
-            if 'in vm_state' not in e.message:
-                raise
+        execute_provider_action(user, driver, identity, instance, action)
     return True  # User was over_allocation
 
 
@@ -546,3 +519,70 @@ def _get_strategy(identity):
         return identity.provider.allocationstrategy
     except CoreAllocationStrategy.DoesNotExist:
         return None
+
+
+def allocation_source_overage_enforcement(allocation_source):
+    for user in allocation_source.all_users():
+        for identity in user.current_identities:
+            allocation_source_overage_enforcement_for(allocation_source, user, identity)
+
+
+def filter_allocation_source_instances(allocation_source, esh_instances):
+    as_instances = []
+    for inst in esh_instances:
+        provider_alias = inst.id
+        snapshot = InstanceAllocationSourceSnapshot.objects.filter(
+            instance__provider_alias=provider_alias).first()
+        if snapshot and snapshot.allocation_source == allocation_source:
+            as_instances.append(inst)
+    return as_instances
+
+
+def allocation_source_overage_enforcement_for(allocation_source, user, identity):
+    provider = identity.provider
+    action = provider.over_allocation_action
+    if not action:
+        logger.debug("No 'over_allocation_action' provided for %s" % provider)
+        return False  # Over_allocation was not attempted
+    if not settings.ENFORCING:
+        logger.info("Settings dictate that ENFORCING = False. Returning..")
+        return False
+    driver = get_cached_driver(identity=identity)
+    esh_instances = driver.list_instances()
+    filtered_instances = filter_allocation_source_instances(allocation_source, esh_instances)
+    # TODO: Parallelize this operation so you don't wait for larger instances
+    # to finish 'wait_for' task below..
+    for instance in filtered_instances:
+        execute_provider_action(user, driver, identity, instance, action)
+    return True  # Over_allocation enforment was attempted
+
+def execute_provider_action(user, driver, identity, instance, action):
+    try:
+        if driver._is_active_instance(instance):
+            # Suspend active instances, update the task in the DB
+            # NOTE: identity.created_by COULD BE the Admin User, indicating that this action/InstanceHistory was
+            #       executed by the administrator.. Future Release Idea.
+            _execute_provider_action(
+                identity,
+                identity.created_by,
+                instance,
+                action.name)
+            # NOTE: Intentionally added to allow time for
+            #      the Cloud to begin 'suspend' operation
+            #      before querying for the instance again.
+            # TODO: Instead: Add "wait_for" change from active to any
+            # terminal, non-active state?
+            wait_time = random.uniform(2, 6)
+            time.sleep(wait_time)
+            updated_esh = driver.get_instance(instance.id)
+            convert_esh_instance(
+                driver, updated_esh,
+                identity.provider.uuid,
+                identity.uuid,
+                user)
+    except Exception as e:
+        # Raise ANY exception that doesn't say
+        # 'This instance is already in the requested VM state'
+        # NOTE: This is OpenStack specific
+        if 'in vm_state' not in e.message:
+            raise


### PR DESCRIPTION
- Disables 'monitor_instance_allocations'
- New hook listens on AllocationSourceSnapshot. If the compute is >100%, enforce allocations (once, and note it in the event, and ignore it for all future calls where compute is >100%)
- Run the enforcement task Asynchronously so that users are not "stuck inside the hook"
- Move from `pre_save` to `post_save` for `listen_before_allocation_snapshot_changes`