### PR TITLE
Problem: On Jetstream production server allocation usage calculation …

### DIFF
--- a/service/allocation_logic.py
+++ b/service/allocation_logic.py
@@ -84,7 +84,7 @@ def get_all_histories_for_instance(instances, report_start_date, report_end_date
                 ~Q(
                     Q(end_date__isnull=False) & Q(end_date__lte=report_start_date)
                   )
-            )
+            ).order_by('start_date')
 
     return histories
 


### PR DESCRIPTION
…is wrong

Solution: Specify an explicit ordering when querying instance_status_history.

It turns out that on the Jetstream server these are returned in reverse chronological order by default. This caused the calculation to be completely wrong.