### PR TITLE
Fix instance hung indefinitely in active deploy

### DIFF
--- a/service/tasks/driver.py
+++ b/service/tasks/driver.py
@@ -1089,7 +1089,7 @@ def _deploy_instance_for_user(driverCls, provider, identity, instance_id,
 
 @task(name="_deploy_instance",
       default_retry_delay=124,
-      time_limit=32 * 60,  # 32 minute hard-set time limit.
+      soft_time_limit=32 * 60,  # 32 minute hard-set time limit.
       max_retries=10
       )
 def _deploy_instance(driverCls, provider, identity, instance_id,


### PR DESCRIPTION
A user's instance was stuck in "active-deploying". After several re-deploys, I looked into the culprit. The instance deploy task will retry until it fails. Once it fails we call another task to update the instance with status "error-deploy error". That second task was never called.

It turns out that if the time limit is exceeded (while it's retrying) the first task is terminated and the second is never run. By using a soft time limit, the second will get a chance to do cleanup, if a timeout occurs.

I verified that this was indeed the culprit by testing very small time_limits and small soft_time_limits to compare.