### PR TITLE
Problem: Jetstream and EventTable tests fail with default settings

### DIFF
--- a/core/tests/models/test_event_table.py
+++ b/core/tests/models/test_event_table.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from api.tests.factories import UserFactory
 from core.models import EventTable, AllocationSource
@@ -9,6 +9,7 @@ class EventTableTest(TestCase):
     def setUp(self):
         pass
 
+    @override_settings(ALLOCATION_SOURCE_WARNINGS=[10, 25, 50, 75, 90])
     def test_create_event(self):
         event_count = EventTable.objects.count()
         self.assertEqual(event_count, 0)

--- a/jetstream/test_tas_api.py
+++ b/jetstream/test_tas_api.py
@@ -2,6 +2,7 @@ import json
 
 import vcr
 from django.test import TestCase
+from django.conf import settings
 from mock import Mock
 
 from test_utils.cassette_utils import assert_cassette_playback_length, scrub_host_name
@@ -17,6 +18,10 @@ my_vcr = vcr.VCR(
 
 class TestJetstream(TestCase):
     """Tests for Jetstream allocation source API"""
+
+    def setUp(self):
+        if 'jetstream' not in settings.INSTALLED_APPS:
+            self.skipTest('jetstream not in settings.INSTALLED_APPS')
 
     @my_vcr.use_cassette()
     def test_validate_account(self, cassette):


### PR DESCRIPTION
Solution: A. Skip Jetstream tests if the 'jetstream' app is not enabled, and B. override the allocation source warning thresholds to work with the EventTable test logic.