### PR TITLE
Fix requirements hook falsy test

### DIFF
--- a/contrib/requirements-warning.rb
+++ b/contrib/requirements-warning.rb
@@ -1,24 +1,19 @@
-DEBUG = false
-
 # Get the commits before the merge
 #   ex. heads = ["<latest commit of master>", "<previous commit of master>", ...]
 heads = `git reflog -n 2 | awk '{ print $1 }'`.split
 
 # Make sure our revision history has at least 2 entries
 if heads.length < 2
-    exit 0 
+    exit 0
 end
 
-files = `git diff --name-only #{heads[1]} #{heads[0]} | grep requirements.txt`
-diffFiles = `git diff --name-only #{heads[1]} #{heads[0]} | grep requirements.txt | tr "\n" " "`
-if diffFiles then
-    default = "\e[0m"
-    red = "\e[31m" 
-    puts "[#{red}requirements-warning.rb hook#{default}]: New python requirements."
-    puts "pip install #{diffFiles}"
+# Get all files that changed
+files = `git diff --name-only #{heads[1]} #{heads[0]}`
 
-    if DEBUG then
-        # Print the diff with 0 lines of context
-        puts `git diff -U0 #{heads[1]} #{heads[0]} -- #{diffFiles}`
-    end
+# If (dev_)requrements.txt changed, alert the user!
+if /requirements.txt/.match files  then
+    default = "\e[0m"
+    red = "\e[31m"
+    puts "[#{red}requirements-warning.rb hook#{default}]: New python requirements."
+    puts "pip install *requirements.txt"
 end

--- a/contrib/requirements-warning.rb
+++ b/contrib/requirements-warning.rb
@@ -11,7 +11,7 @@ end
 files = `git diff --name-only #{heads[1]} #{heads[0]}`
 
 # If (dev_)requrements.txt changed, alert the user!
-if /requirements.txt/.match files  then
+if /requirements.txt/ =~ files
     default = "\e[0m"
     red = "\e[31m"
     puts "[#{red}requirements-warning.rb hook#{default}]: New python requirements."


### PR DESCRIPTION
Only `nil` and only `false` are falsy in ruby. I made the mistake of thinking the empty string was falsy.

Now the hook should only speak up when it's supposed to!