### PR TITLE
Fix search 🎉 

### DIFF
--- a/api/v2/views/image.py
+++ b/api/v2/views/image.py
@@ -9,6 +9,39 @@ from api.v2.views.mixins import MultipleFieldLookup
 from core.models import Application as Image
 
 
+#
+# The following imports and method and monkey patch are a quick fix for a big
+# problem.  The patch should be removed when the equivalent drf method does
+# not chain filter methods. Chaining filter methods with m2m relations,
+# can result in /very/ bad performance. For more information see:
+#
+#   https://code.djangoproject.com/ticket/27303#comment:26
+#
+from django.utils import six; from django.db import models; import operator
+def filter_queryset(self, request, queryset, view):
+    search_fields = getattr(view, 'search_fields', None)
+    search_terms = self.get_search_terms(request)
+
+    if not search_fields or not search_terms:
+        return queryset
+
+    orm_lookups = [
+        self.construct_search(six.text_type(search_field))
+        for search_field in search_fields
+    ]
+
+    conditions = []
+    for search_term in search_terms:
+        queries = [
+            models.Q(**{orm_lookup: search_term})
+            for orm_lookup in orm_lookups
+        ]
+        conditions.append(reduce(operator.or_, queries))
+
+    return queryset.filter(reduce(operator.and_, conditions)).distinct()
+
+filters.SearchFilter.filter_queryset = filter_queryset
+
 class ImageFilter(filters.FilterSet):
     created_by = django_filters.CharFilter('created_by__username')
     project_id = django_filters.CharFilter('projects__uuid')

--- a/api/v2/views/image.py
+++ b/api/v2/views/image.py
@@ -93,4 +93,4 @@ class ImageViewSet(MultipleFieldLookup, AuthOptionalViewSet):
 
     def get_queryset(self):
         request_user = self.request.user
-        return Image.current_apps(request_user)
+        return Image.images_for_user(request_user)

--- a/core/models/application.py
+++ b/core/models/application.py
@@ -118,7 +118,7 @@ class Application(models.Model):
         from core.models.user import AtmosphereUser
         is_public = Q(private=False)
         if not user or isinstance(user, AnonymousUser):
-            return Application.objects.filter(is_public).distinct()
+            return Application.objects.filter(only_current() & is_public).distinct()
         if not isinstance(user, AtmosphereUser):
             raise Exception("Expected user to be of type AtmosphereUser"
                             " - Received %s" % type(user))

--- a/core/query.py
+++ b/core/query.py
@@ -268,3 +268,23 @@ def _query_membership_for_user(user):
     if not user:
         return None
     return Q(group__id__in=user.group_set.values('id'))
+
+def images_shared_with_user(user):
+    """
+    Images with versions or machines belonging to the user's groups
+    """
+    group_ids = user.group_ids()
+    return (Q(versions__machines__members__id__in=group_ids) |
+        Q(versions__membership__id__in=group_ids))
+
+def created_by_user(user):
+    """
+    Images created by a username
+    """
+    return Q(created_by__username__exact=user.username)
+
+def in_users_providers(user):
+    """
+    Images on providers that the user belongs to
+    """
+    return Q(versions__machines__instance_source__provider__in=user.current_providers)


### PR DESCRIPTION
There was an exponential slowdown when a user searched for images. Without getting into the details `filter(testA).filter(testB).filter(testC)` can result in very very bad sql. django-rest-framework was doing this and we were as well. The solution is to use `filter(testA & testB & testC)`. Rather than wait for drf to fix this issue, we have monkey patched the troublesome method (when they release a fix, we'll revert the patch).

Read a ticket I filed against Django:
https://code.djangoproject.com/ticket/27388

Here is a general thread:
https://code.djangoproject.com/ticket/27303

Here is a rough estimate of the performance for the underlying sql, based on the number of terms in a search.

```
# terms    time(ms)
===================
1          0.047
2          0.056
3          0.066
4          0.076
5          0.093
6          0.108
7          0.117
8          0.124
9          0.140
10         0.149
```

For perspective, 2 terms used to take ~36s on my dev box.
