### PR TITLE
Instance reporting by API

### DIFF
--- a/api/pagination.py
+++ b/api/pagination.py
@@ -24,7 +24,6 @@ def _get_count(queryset):
         return len(queryset)
 
 class StandardResultsSetPagination(PageNumberPagination):
-    max_page_size = 1000
     page_size = 100
     page_size_query_param = 'page_size'
 

--- a/api/pagination.py
+++ b/api/pagination.py
@@ -24,6 +24,7 @@ def _get_count(queryset):
         return len(queryset)
 
 class StandardResultsSetPagination(PageNumberPagination):
+    max_page_size = 1000
     page_size = 100
     page_size_query_param = 'page_size'
 

--- a/api/renderers.py
+++ b/api/renderers.py
@@ -1,4 +1,44 @@
+from django.http import StreamingHttpResponse
+
 from rest_framework import renderers
+from rest_framework_csv.renderers import CSVRenderer
+
+from StringIO import StringIO
+import pandas as pd
+
+
+class PandasExcelRenderer(CSVRenderer):
+    """
+    Renderer which serializes to XLS
+    """
+
+    media_type = 'application/vnd.ms-excel'
+    format = 'xlsx'
+
+    def render(self, data, media_type=None, renderer_context={}):
+        filename = renderer_context.get('filename', 'workbook.xlsx')
+        # Hard-coded headers_ordering required to force an explicit ordering, otherwise headers are sorted by key-name
+        headers_ordering = renderer_context.get('headers_ordering', None)
+        table = self.tablize(data, header=headers_ordering)
+
+        headers = table.pop(0)
+        raw_dataframe = pd.DataFrame(table, columns=headers)
+        #Save to StringIO
+        sio = StringIO()
+        writer = pd.ExcelWriter(sio, engine='xlsxwriter')
+        if 'excel_writer_hook' not in renderer_context:
+            raise Exception("Implementation error -- Using PandasExcelRenderer without including 'excel_writer_hook' in renderer_context")
+
+        callback = renderer_context.get('excel_writer_hook')
+        writer = callback(raw_dataframe, writer)
+        # ASSERT: Writer should be saved by now
+        # StringIO to response:
+        sio.seek(0)
+        workbook = sio.getvalue()
+        response = StreamingHttpResponse(workbook, content_type='application/vnd.ms-excel')
+        #FIXME: This doesn't... actually.. work. Filename == pathname.
+        response['Content-Disposition'] = 'attachment; filename="%s"' % filename
+        return response
 
 
 class PNGRenderer(renderers.BaseRenderer):

--- a/api/v2/serializers/details/__init__.py
+++ b/api/v2/serializers/details/__init__.py
@@ -34,6 +34,7 @@ from .provider_machine import ProviderMachineSerializer
 from .quota import QuotaSerializer, AllocationSerializer
 from .resource_request import (
     ResourceRequestSerializer, UserResourceRequestSerializer)
+from .reporting import InstanceReportingSerializer
 from .size import SizeSerializer
 from .ssh_key import SSHKeySerializer
 from .status_type import StatusTypeSerializer

--- a/api/v2/serializers/details/reporting.py
+++ b/api/v2/serializers/details/reporting.py
@@ -1,0 +1,117 @@
+from core.models import (
+    Instance
+)
+from rest_framework import serializers
+from api.v2.serializers.fields.base import UUIDHyperlinkedIdentityField
+
+from api.v2.serializers.summaries import (
+    SizeSummarySerializer,
+)
+
+
+class InstanceReportingSerializer(serializers.ModelSerializer):
+    instance_id = serializers.CharField(source="provider_alias", read_only=True)
+    username = serializers.CharField(source="created_by.username", read_only=True)
+    staff_user = serializers.CharField(source="created_by.is_staff", read_only=True)
+    provider = serializers.CharField(source='created_by_identity.provider.location', read_only=True)
+    size = serializers.SerializerMethodField()
+    image_name = serializers.SerializerMethodField()
+    version_name = serializers.SerializerMethodField()
+    is_featured_image = serializers.SerializerMethodField()
+    hit_aborted = serializers.SerializerMethodField()
+    hit_active = serializers.SerializerMethodField()
+    hit_deploy_error = serializers.SerializerMethodField()
+    hit_error = serializers.SerializerMethodField()
+    hit_active_or_aborted = serializers.SerializerMethodField()
+    hit_active_or_aborted_or_error = serializers.SerializerMethodField()
+
+    def get_size(self, obj):
+        size = obj.get_size()
+        serializer = SizeSummarySerializer(size, context=self.context)
+        return serializer.data
+
+    def get_is_featured_image(self, instance):
+        try:
+            application = self.get_application(instance)
+            return application.tags.filter(name__icontains='featured').count() > 0
+        except Exception:
+            return False
+
+    def get_version_name(self, instance):
+        try:
+            version = self.get_version(instance)
+            return version.name
+        except Exception:
+            return "N/A"
+
+    def get_image_name(self, instance):
+        try:
+            application = self.get_application(instance)
+            return application.name
+        except Exception:
+            return "Deleted Image"
+
+    def get_application(self, instance):
+        try:
+            version = self.get_version(instance)
+            return version.application
+        except Exception:
+            return None
+
+    def get_version(self, instance):
+        try:
+            return instance.source.providermachine.application_version
+        except Exception:
+            return None
+
+    def get_hit_active_or_aborted_or_error(self, instance):
+        return 1 if (
+            self.get_hit_active(instance) or
+            self.get_hit_aborted(instance) or
+            self.get_hit_error(instance)
+        ) else 0
+
+    def get_hit_active_or_aborted(self, instance):
+        return 1 if (
+            self.get_hit_active(instance) or
+            self.get_hit_aborted(instance)
+        ) else 0
+
+    def get_hit_aborted(self, instance):
+        return (
+            not self.get_hit_active(instance) and
+            not self.get_hit_deploy_error(instance) and
+            not self.get_hit_error(instance)
+        )
+
+    def get_hit_active(self, instance):
+        return instance.instancestatushistory_set.filter(status__name='active').count() > 0
+
+    def get_hit_deploy_error(self, instance):
+        return instance.instancestatushistory_set.filter(status__name='deploy_error').count() > 0
+
+    def get_hit_error(self, instance):
+        return instance.instancestatushistory_set.filter(status__name='error').count() > 0
+
+    class Meta:
+        model = Instance
+        fields = (
+            'id',
+            'instance_id',
+            'username',
+            'staff_user',
+            'provider',
+            'image_name',
+            'version_name',
+            'is_featured_image',
+            'hit_aborted',
+            'hit_active_or_aborted',
+            'hit_active_or_aborted_or_error',
+            'hit_active',
+            'hit_deploy_error',
+            'hit_error',
+            'size',
+            'start_date',
+            'end_date',
+        )
+

--- a/api/v2/serializers/details/reporting.py
+++ b/api/v2/serializers/details/reporting.py
@@ -68,7 +68,7 @@ class InstanceReportingSerializer(serializers.ModelSerializer):
             return None
 
     def get_end_date(self, instance):
-        return instance.end_date.strftime("%x %X") if instance.end_date else timezone.now().strftime("%x %X")
+        return instance.end_date.strftime("%x %X") if instance.end_date else None
 
     def get_start_date(self, instance):
         return instance.start_date.strftime("%x %X")

--- a/api/v2/serializers/details/reporting.py
+++ b/api/v2/serializers/details/reporting.py
@@ -2,6 +2,7 @@ from core.models import (
     Instance
 )
 from rest_framework import serializers
+from django.utils import timezone
 from api.v2.serializers.fields.base import UUIDHyperlinkedIdentityField
 
 from api.v2.serializers.summaries import (
@@ -18,6 +19,8 @@ class InstanceReportingSerializer(serializers.ModelSerializer):
     image_name = serializers.SerializerMethodField()
     version_name = serializers.SerializerMethodField()
     is_featured_image = serializers.SerializerMethodField()
+    start_date = serializers.SerializerMethodField()
+    end_date = serializers.SerializerMethodField()
     hit_aborted = serializers.SerializerMethodField()
     hit_active = serializers.SerializerMethodField()
     hit_deploy_error = serializers.SerializerMethodField()
@@ -40,14 +43,14 @@ class InstanceReportingSerializer(serializers.ModelSerializer):
     def get_version_name(self, instance):
         try:
             version = self.get_version(instance)
-            return version.name
+            return version.name.replace(",","-")
         except Exception:
             return "N/A"
 
     def get_image_name(self, instance):
         try:
             application = self.get_application(instance)
-            return application.name
+            return application.name.replace(",", "-")
         except Exception:
             return "Deleted Image"
 
@@ -63,6 +66,12 @@ class InstanceReportingSerializer(serializers.ModelSerializer):
             return instance.source.providermachine.application_version
         except Exception:
             return None
+
+    def get_end_date(self, instance):
+        return instance.end_date.strftime("%x %X") if instance.end_date else timezone.now().strftime("%x %X")
+
+    def get_start_date(self, instance):
+        return instance.start_date.strftime("%x %X")
 
     def get_hit_active_or_aborted_or_error(self, instance):
         return 1 if (

--- a/api/v2/urls.py
+++ b/api/v2/urls.py
@@ -72,6 +72,7 @@ router.register(
 router.register(r'provider_types', views.ProviderTypeViewSet, base_name='providertype')
 router.register(r'quotas', views.QuotaViewSet)
 router.register(r'resource_requests', views.ResourceRequestViewSet)
+router.register(r'reporting', views.ReportingViewSet, base_name='reporting')
 router.register(r'sizes', views.SizeViewSet)
 router.register(r'status_types', views.StatusTypeViewSet)
 router.register(r'tags', views.TagViewSet)

--- a/api/v2/views/__init__.py
+++ b/api/v2/views/__init__.py
@@ -36,6 +36,7 @@ from .provider_machine import ProviderMachineViewSet
 from .provider_type import ProviderTypeViewSet
 from .quota import QuotaViewSet
 from .resource_request import ResourceRequestViewSet
+from .reporting import ReportingViewSet
 from .size import SizeViewSet
 from .status_type import StatusTypeViewSet
 from .email import  InstanceSupportEmailViewSet, VolumeSupportEmailViewSet, FeedbackEmailViewSet, ResourceEmailViewSet

--- a/api/v2/views/emulate.py
+++ b/api/v2/views/emulate.py
@@ -30,7 +30,7 @@ class TokenEmulateViewSet(ViewSet):
         new_token = create_token(
                 username,
                 token_key='EMULATED-'+str(uuid4()),
-                remote_ip=request.META['REMOTE_ADDR'],
+                remote_ip=self.request.META['REMOTE_ADDR'],
                 token_expire=expireDate,
                 issuer="DRF-EmulatedToken-%s" % user.username)
         serialized_data = TokenSerializer(new_token, context={'request':self.request}).data

--- a/api/v2/views/reporting.py
+++ b/api/v2/views/reporting.py
@@ -1,0 +1,128 @@
+"""
+ RESTful Reporting API
+"""
+from dateutil.parser import parse
+
+from django.conf import settings
+from django.template.loader import render_to_string
+from django.template import Context
+from django.db.models import Q
+
+from rest_framework.response import Response
+from rest_framework import status
+
+from api import permissions
+from api.pagination import StandardResultsSetPagination
+from api.v2.views.base import AuthViewSet
+from api.v2.exceptions import failure_response
+from api.v2.serializers.details import InstanceReportingSerializer
+
+from core.models import AtmosphereUser as User
+from core.models import Instance, Volume
+from rest_framework_csv.renderers import CSVRenderer
+from django.http import StreamingHttpResponse
+
+import xlwt, pandas, numpy
+from datetime import datetime, date
+from StringIO import StringIO
+
+class ExcelRenderer(CSVRenderer):
+    """
+    Renderer which serializes to XLS
+    """
+
+    media_type = 'application/vnd.ms-excel'
+    format = 'xlsx'
+
+    def render(self, data, media_type=None, renderer_context={}):
+        sheetname = renderer_context.get('sheetname', 'raw_data')
+        filename = renderer_context.get('filename', 'workbook.xlsx')
+
+        table = self.tablize(data)
+        headers = table.pop(0)
+        df = pandas.DataFrame(table, columns=headers)
+        #Save to StringIO
+        sio = StringIO()
+        writer = pandas.ExcelWriter(sio, engine='xlsxwriter')
+        df.to_excel(writer, sheet_name=sheetname)
+        # Get access to the workbook and sheet
+        if 'excel_callback' in renderer_context:
+            callback = renderer_context.get('excel_callback')
+            callback(df, writer)
+
+        writer.save()
+
+        # StringIO to response:
+        sio.seek(0)
+        workbook = sio.getvalue()
+        response = StreamingHttpResponse(workbook, content_type='application/vnd.ms-excel')
+        response['Content-Disposition'] = 'attachment; filename="%s"' % filename
+        return response
+
+
+class ReportingViewSet(AuthViewSet):
+    renderer_classes = [ExcelRenderer, ]
+    pagination_class = None
+    serializer_class = InstanceReportingSerializer
+    ordering_fields = ('id', 'start_date')
+    http_method_names = ['get', 'head', 'options', 'trace']
+
+    class Meta:
+        model = Instance
+
+    def add_to_worksheet(self, df, writer):
+
+        table = pandas.pivot_table(
+            df, index=[
+                'is_featured_image','staff_user','start_date', 'image_name'],
+            aggfunc={
+                'hit_active_or_aborted_or_error': [numpy.mean],
+                'hit_active_or_aborted': [numpy.mean]}
+        )
+        table.query('is_featured_image == 1')
+        table.query('staff_user == 1')
+        table.to_excel(writer, 'pivot')
+        # Get access to the workbook and sheet
+        # workbook = writer.book
+        # worksheet = writer.sheets['raw_data']
+        return (df, writer)
+
+    def get_renderer_context(self):
+        return {
+            'filename': 'reporting.xlsx',
+            'excel_callback': self.add_to_worksheet,
+        }
+
+    def _filter_by_request(self):
+        instances_qs = Instance.objects.all()
+        query_params = self.request.query_params
+
+        if 'provider_id' in query_params:
+            provider_id_list = query_params.getlist('provider_id')
+            provider_ids = [int(pid) for pid in provider_id_list]
+            instances_qs &= Instance.objects.filter(created_by_identity__provider__id__in=provider_ids)
+
+        if 'start_date' in query_params:
+            start_date = parse(query_params['start_date'])
+            instances_qs &= Instance.objects.filter(start_date__gt=start_date)
+
+        if 'end_date' in query_params:
+            end_date = parse(query_params['end_date'])
+            query = Q(end_date__lt=end_date)
+            #FIXME: not sure how to address this, but in some cases,
+            # you want to set an 'end-date' for the reporting, but *not*
+            # explicitly setting an end-date on the instance.
+            # For now, i've recorded this idea as 'include_current'
+            # To avoid 'missing' metrtics, we will always include current instances.
+            if query_params.get('include_current') != False:
+                query |= Q(end_date__isnull=True)
+            instances_qs &= Instance.objects.filter(query)
+
+        return instances_qs
+
+    def get_queryset(self):
+        return self._filter_by_request()
+
+    def get(self, request, pk=None):
+        return self.list(request)
+

--- a/api/v2/views/reporting.py
+++ b/api/v2/views/reporting.py
@@ -20,13 +20,14 @@ from api.v2.serializers.details import InstanceReportingSerializer
 from core.models import AtmosphereUser as User
 from core.models import Instance, Volume
 from rest_framework_csv.renderers import CSVRenderer
+from rest_framework.settings import api_settings
 from django.http import StreamingHttpResponse
 
-import xlwt, pandas, numpy
+import xlwt, pandas, numpy, pytz
 from datetime import datetime, date
 from StringIO import StringIO
 
-class ExcelRenderer(CSVRenderer):
+class PandasExcelRenderer(CSVRenderer):
     """
     Renderer which serializes to XLS
     """
@@ -37,18 +38,18 @@ class ExcelRenderer(CSVRenderer):
     def render(self, data, media_type=None, renderer_context={}):
         sheetname = renderer_context.get('sheetname', 'raw_data')
         filename = renderer_context.get('filename', 'workbook.xlsx')
-
-        table = self.tablize(data)
+        header_list = ["id", "instance_id", "username", "staff_user", "provider", "start_date", "end_date", "image_name", "version_name", "size.active", "size.start_date", "size.end_date", "size.name", "size.id", "size.uuid", "size.url", "size.alias", "size.cpu", "size.mem", "size.disk", "is_featured_image", "hit_active", "hit_deploy_error", "hit_error", "hit_aborted", "hit_active_or_aborted", "hit_active_or_aborted_or_error"]
+        table = self.tablize(data, header=header_list)
+        #table = self.tablize(data)
         headers = table.pop(0)
         df = pandas.DataFrame(table, columns=headers)
         #Save to StringIO
         sio = StringIO()
         writer = pandas.ExcelWriter(sio, engine='xlsxwriter')
-        df.to_excel(writer, sheet_name=sheetname)
+        if 'writer_callback' in renderer_context:
+            callback = renderer_context.get('writer_callback')
+            df, writer = callback(df, writer, sheetname)
         # Get access to the workbook and sheet
-        if 'excel_callback' in renderer_context:
-            callback = renderer_context.get('excel_callback')
-            callback(df, writer)
 
         writer.save()
 
@@ -61,7 +62,7 @@ class ExcelRenderer(CSVRenderer):
 
 
 class ReportingViewSet(AuthViewSet):
-    renderer_classes = [ExcelRenderer, ]
+    renderer_classes = api_settings.DEFAULT_RENDERER_CLASSES + [PandasExcelRenderer, ]
     pagination_class = None
     serializer_class = InstanceReportingSerializer
     ordering_fields = ('id', 'start_date')
@@ -70,54 +71,87 @@ class ReportingViewSet(AuthViewSet):
     class Meta:
         model = Instance
 
-    def add_to_worksheet(self, df, writer):
+    def write_excel(self, df, writer, sheetname):
+        if len(df.index) <= 1:
+            return (df, writer)
+        df['start_date'] = df['start_date'].apply(pandas.to_datetime)
+        df['end_date'] = df['end_date'].apply(pandas.to_datetime)
+        new_df = df.set_index(['start_date', 'image_name'])
+        new_df = new_df.groupby([pandas.Grouper(freq='MS', level=0), new_df.index.get_level_values(1)]).mean()
+        new_df = new_df.query('is_featured_image == 1')
+        new_df = new_df.drop(['is_featured_image', 'hit_active', 'hit_aborted', 'hit_deploy_error', 'hit_error', 'id', 'size.active', 'size.cpu', 'size.disk', 'size.id', 'size.mem'], axis=1)
+        new_df.index.rename(['Start Date', 'Image Name'], inplace=True)
+        new_df.columns = ['Average of Active/Aborted', 'Average of Active/Aborted/Error']
 
-        table = pandas.pivot_table(
-            df, index=[
-                'is_featured_image','staff_user','start_date', 'image_name'],
-            aggfunc={
-                'hit_active_or_aborted_or_error': [numpy.mean],
-                'hit_active_or_aborted': [numpy.mean]}
-        )
-        table.query('is_featured_image == 1')
-        table.query('staff_user == 1')
-        table.to_excel(writer, 'pivot')
-        # Get access to the workbook and sheet
-        # workbook = writer.book
-        # worksheet = writer.sheets['raw_data']
-        return (df, writer)
+        #Write to excel.
+        writer.datetime_format = 'mmm yyyy'
+        new_df.to_excel(writer, 'Summary')
+
+        writer.datetime_format = 'mmm d yyyy hh:mm:ss'
+        df.to_excel(writer, sheet_name=sheetname)
+
+        import ipdb;ipdb.set_trace()
+
+        # Set workbook formatting after writing
+        workbook  = writer.book
+        pct_format = workbook.add_format({'num_format': '0.00%'})
+        name_format = workbook.add_format({'align': 'left'})
+
+        raw_ws = writer.sheets[sheetname]
+        summary_ws = writer.sheets['Summary']
+
+        # Set worksheet formatting
+        raw_ws.autofilter(0,0,len(df.values),len(df.columns))
+
+        summary_ws.set_column('A2:A', 34)
+        summary_ws.set_column('B:B', 36, name_format)
+        summary_ws.set_column('C:C', 21, pct_format)
+        summary_ws.set_column('D:D', 26, pct_format)
+        return (new_df, writer)
+
+    def list(self, request, *args, **kwargs):
+        """
+        """
+        query_params = self.request.query_params
+        if not query_params.items():
+            return failure_response(status.HTTP_400_BAD_REQUEST, "The reporting API should be accessed via the query parameters: ['start_date', 'end_date', 'provider_id']")
+        return super(ReportingViewSet, self).list(request, *args, **kwargs)
 
     def get_renderer_context(self):
+        """
+        Returns a dict that is passed through to Renderer.render(),
+        as the `renderer_context` keyword argument.
+        """
+        # Note: Additionally 'response' will also be added to the context,
+        #       by the Response object.
         return {
+            'view': self,
+            'args': getattr(self, 'args', ()),
+            'kwargs': getattr(self, 'kwargs', {}),
+            'request': getattr(self, 'request', None),
             'filename': 'reporting.xlsx',
-            'excel_callback': self.add_to_worksheet,
+            'writer_callback': self.write_excel,
         }
 
     def _filter_by_request(self):
         instances_qs = Instance.objects.all()
         query_params = self.request.query_params
+        query = Q()
 
         if 'provider_id' in query_params:
             provider_id_list = query_params.getlist('provider_id')
             provider_ids = [int(pid) for pid in provider_id_list]
-            instances_qs &= Instance.objects.filter(created_by_identity__provider__id__in=provider_ids)
-
+            query &= Q(created_by_identity__provider__id__in=provider_ids)
+        #NOTE: All times assumed UTC.. Trust me on this one.
         if 'start_date' in query_params:
-            start_date = parse(query_params['start_date'])
-            instances_qs &= Instance.objects.filter(start_date__gt=start_date)
+            start_date = parse(query_params['start_date']).replace(tzinfo=pytz.utc)
+            query &= Q(start_date__gt=start_date)
 
         if 'end_date' in query_params:
-            end_date = parse(query_params['end_date'])
-            query = Q(end_date__lt=end_date)
-            #FIXME: not sure how to address this, but in some cases,
-            # you want to set an 'end-date' for the reporting, but *not*
-            # explicitly setting an end-date on the instance.
-            # For now, i've recorded this idea as 'include_current'
-            # To avoid 'missing' metrtics, we will always include current instances.
-            if query_params.get('include_current') != False:
-                query |= Q(end_date__isnull=True)
-            instances_qs &= Instance.objects.filter(query)
+            end_date = parse(query_params['end_date']).replace(tzinfo=pytz.utc)
+            query &= Q(start_date__lt=end_date)
 
+        instances_qs = Instance.objects.filter(query)
         return instances_qs
 
     def get_queryset(self):

--- a/api/v2/views/reporting.py
+++ b/api/v2/views/reporting.py
@@ -42,13 +42,13 @@ class PandasExcelRenderer(CSVRenderer):
         table = self.tablize(data, header=header_list)
         #table = self.tablize(data)
         headers = table.pop(0)
-        df = pandas.DataFrame(table, columns=headers)
+        raw_dataframe = pandas.DataFrame(table, columns=headers)
         #Save to StringIO
         sio = StringIO()
         writer = pandas.ExcelWriter(sio, engine='xlsxwriter')
         if 'writer_callback' in renderer_context:
             callback = renderer_context.get('writer_callback')
-            df, writer = callback(df, writer, sheetname)
+            raw_dataframe, writer = callback(raw_dataframe, writer, sheetname)
         # Get access to the workbook and sheet
 
         writer.save()
@@ -71,43 +71,73 @@ class ReportingViewSet(AuthViewSet):
     class Meta:
         model = Instance
 
-    def write_excel(self, df, writer, sheetname):
-        if len(df.index) <= 1:
-            return (df, writer)
-        df['start_date'] = df['start_date'].apply(pandas.to_datetime)
-        df['end_date'] = df['end_date'].apply(pandas.to_datetime)
-        new_df = df.set_index(['start_date', 'image_name'])
-        new_df = new_df.groupby([pandas.Grouper(freq='MS', level=0), new_df.index.get_level_values(1)]).mean()
-        new_df = new_df.query('is_featured_image == 1')
-        new_df = new_df.drop(['is_featured_image', 'hit_active', 'hit_aborted', 'hit_deploy_error', 'hit_error', 'id', 'size.active', 'size.cpu', 'size.disk', 'size.id', 'size.mem'], axis=1)
-        new_df.index.rename(['Start Date', 'Image Name'], inplace=True)
-        new_df.columns = ['Average of Active/Aborted', 'Average of Active/Aborted/Error']
+    def write_excel(self, raw_dataframe, writer, sheetname):
+        if len(raw_dataframe.index) <= 1:
+            return (raw_dataframe, writer)
+        raw_dataframe['start_date'] = raw_dataframe['start_date'].apply(pandas.to_datetime)
+        raw_dataframe['end_date'] = raw_dataframe['end_date'].apply(pandas.to_datetime)
 
+        user_summary_data = raw_dataframe.set_index(['start_date', 'username'])
+        user_summary_data = user_summary_data.groupby([pandas.Grouper(freq='MS', level=0), user_summary_data.index.get_level_values(1)]).sum()
+        user_summary_data = user_summary_data.query('is_featured_image == 1')
+        user_summary_data = user_summary_data.drop(['is_featured_image', 'hit_error', 'id', 'size.active', 'size.cpu', 'size.disk', 'size.id', 'size.mem'], axis=1)
+        user_summary_data.index.rename(['Start Date', 'Username'], inplace=True)
+        user_summary_data.columns = ['Sum of Active', 'Sum of Aborted', 'Sum of Deploy Error', 'Sum of Active/Aborted', 'Sum of Active/Aborted/Error']
+
+        image_summary_data = raw_dataframe.set_index(['start_date', 'image_name'])
+        image_summary_data = image_summary_data.groupby([pandas.Grouper(freq='MS', level=0), image_summary_data.index.get_level_values(1)]).mean()
+        image_summary_data = image_summary_data.query('is_featured_image == 1')
+        image_summary_data = image_summary_data.drop(['is_featured_image', 'hit_active', 'hit_aborted', 'hit_deploy_error', 'hit_error', 'id', 'size.active', 'size.cpu', 'size.disk', 'size.id', 'size.mem'], axis=1)
+        image_summary_data.index.rename(['Start Date', 'Image Name'], inplace=True)
+        image_summary_data.columns = ['Average of Active/Aborted', 'Average of Active/Aborted/Error']
+        raw_dataframe = raw_dataframe.drop(['size.id', 'size.uuid', 'size.alias', 'size.active', 'size.start_date', 'size.end_date','size.url'], axis=1)
         #Write to excel.
         writer.datetime_format = 'mmm yyyy'
-        new_df.to_excel(writer, 'Summary')
+        image_summary_data.to_excel(writer, 'Image Summary')
+        user_summary_data.to_excel(writer, 'User Summary')
 
         writer.datetime_format = 'mmm d yyyy hh:mm:ss'
-        df.to_excel(writer, sheet_name=sheetname)
-
-        import ipdb;ipdb.set_trace()
+        raw_dataframe.to_excel(writer, sheet_name=sheetname)
 
         # Set workbook formatting after writing
-        workbook  = writer.book
+        workbook = writer.book
         pct_format = workbook.add_format({'num_format': '0.00%'})
-        name_format = workbook.add_format({'align': 'left'})
+        name_format = workbook.add_format()
+        name_format.set_align('left')
 
         raw_ws = writer.sheets[sheetname]
-        summary_ws = writer.sheets['Summary']
+        image_summary_ws = writer.sheets['Image Summary']
+        user_summary_ws = writer.sheets['User Summary']
 
         # Set worksheet formatting
-        raw_ws.autofilter(0,0,len(df.values),len(df.columns))
+        raw_ws.autofilter(0, 0, len(raw_dataframe.values), len(raw_dataframe.columns))
+        raw_ws.set_column('C:C', 32)
+        raw_ws.set_column('D:D', 13)
+        raw_ws.set_column('F:F', 23)
+        raw_ws.set_column('G:G', 17)
+        raw_ws.set_column('H:H', 17)
+        raw_ws.set_column('I:I', 34)
+        raw_ws.set_column('J:J', 17)
+        raw_ws.set_column('K:K', 14)
+        raw_ws.set_column('L:L', 14)
+        raw_ws.set_column('M:M', 14)
+        raw_ws.set_column('N:N', 14)
+        raw_ws.set_column('O:O', 14)
+        
+        image_summary_ws.set_column('A2:A', 34)
+        image_summary_ws.set_column('B:B', 36, name_format)
+        image_summary_ws.set_column('C:C', 21, pct_format)
+        image_summary_ws.set_column('D:D', 26, pct_format)
 
-        summary_ws.set_column('A2:A', 34)
-        summary_ws.set_column('B:B', 36, name_format)
-        summary_ws.set_column('C:C', 21, pct_format)
-        summary_ws.set_column('D:D', 26, pct_format)
-        return (new_df, writer)
+        user_summary_ws.set_column('A2:A', 34)
+        user_summary_ws.set_column('B:B', 13, name_format)
+        user_summary_ws.set_column('C:C', 17)
+        user_summary_ws.set_column('D:D', 17)
+        user_summary_ws.set_column('E:E', 17)
+        user_summary_ws.set_column('F:F', 21)
+        user_summary_ws.set_column('G:G', 21)
+
+        return (image_summary_data, writer)
 
     def list(self, request, *args, **kwargs):
         """
@@ -134,7 +164,11 @@ class ReportingViewSet(AuthViewSet):
         }
 
     def _filter_by_request(self):
-        instances_qs = Instance.objects.all()
+        request_user = self.request.user
+        if request_user.is_staff or request_user.is_superuser:
+            instances_qs = Instance.objects.all()
+        else:
+            instances_qs = Instance.for_user(request_user)
         query_params = self.request.query_params
         query = Q()
 

--- a/api/v2/views/reporting.py
+++ b/api/v2/views/reporting.py
@@ -17,15 +17,15 @@ from api.v2.views.base import AuthViewSet
 from api.v2.exceptions import failure_response
 from api.v2.serializers.details import InstanceReportingSerializer
 
-from core.models import AtmosphereUser as User
-from core.models import Instance, Volume
+from core.models import Instance
 from rest_framework_csv.renderers import CSVRenderer
 from rest_framework.settings import api_settings
 from django.http import StreamingHttpResponse
 
-import xlwt, pandas, numpy, pytz
-from datetime import datetime, date
+import pandas
+import pytz
 from StringIO import StringIO
+
 
 class PandasExcelRenderer(CSVRenderer):
     """

--- a/api/v2/views/reporting.py
+++ b/api/v2/views/reporting.py
@@ -21,7 +21,8 @@ from api.v2.serializers.details import InstanceReportingSerializer
 from core.models import Instance
 from rest_framework.settings import api_settings
 
-import pandas
+import pandas as pd
+import numpy as np
 import pytz
 
 
@@ -34,82 +35,6 @@ class ReportingViewSet(AuthViewSet):
 
     class Meta:
         model = Instance
-
-    def write_excel(self, raw_dataframe, writer, sheetname):
-        if len(raw_dataframe.index) <= 1:
-            return (raw_dataframe, writer)
-        raw_dataframe['start_date'] = raw_dataframe['start_date'].apply(pandas.to_datetime)
-        raw_dataframe['end_date'] = raw_dataframe['end_date'].apply(pandas.to_datetime)
-
-        user_summary_data = raw_dataframe.set_index(['start_date', 'username'])
-        user_summary_data = user_summary_data.groupby([pandas.Grouper(freq='MS', level=0), user_summary_data.index.get_level_values(1)]).sum()
-        user_summary_data = user_summary_data.query('is_featured_image == 1')
-        user_summary_data = user_summary_data.drop(['is_featured_image', 'hit_error', 'id', 'size.active', 'size.cpu', 'size.disk', 'size.id', 'size.mem'], axis=1)
-        user_summary_data.index.rename(['Start Date', 'Username'], inplace=True)
-        user_summary_data.columns = ['Sum of Active', 'Sum of Aborted', 'Sum of Deploy Error', 'Sum of Active/Aborted', 'Sum of Active/Aborted/Error']
-
-        image_summary_data = raw_dataframe.set_index(['start_date', 'image_name'])
-        image_summary_data = image_summary_data.groupby([pandas.Grouper(freq='MS', level=0), image_summary_data.index.get_level_values(1)]).mean()
-        image_summary_data = image_summary_data.query('is_featured_image == 1')
-        image_summary_data = image_summary_data.drop(['is_featured_image', 'hit_active', 'hit_aborted', 'hit_deploy_error', 'hit_error', 'id', 'size.active', 'size.cpu', 'size.disk', 'size.id', 'size.mem'], axis=1)
-        image_summary_data.index.rename(['Start Date', 'Image Name'], inplace=True)
-        image_summary_data.columns = ['Average of Active/Aborted', 'Average of Active/Aborted/Error']
-        raw_dataframe = raw_dataframe.drop(['size.id', 'size.uuid', 'size.alias', 'size.active', 'size.start_date', 'size.end_date','size.url'], axis=1)
-        #Write to excel.
-        writer.datetime_format = 'mmm yyyy'
-        image_summary_data.to_excel(writer, 'Image Summary')
-        user_summary_data.to_excel(writer, 'User Summary')
-
-        writer.datetime_format = 'mmm d yyyy hh:mm:ss'
-        raw_dataframe.to_excel(writer, sheet_name=sheetname)
-
-        # Set workbook formatting after writing
-        workbook = writer.book
-        pct_format = workbook.add_format({'num_format': '0.00%'})
-        name_format = workbook.add_format()
-        name_format.set_align('left')
-
-        raw_ws = writer.sheets[sheetname]
-        image_summary_ws = writer.sheets['Image Summary']
-        user_summary_ws = writer.sheets['User Summary']
-
-        # Set worksheet formatting
-        raw_ws.autofilter(0, 0, len(raw_dataframe.values), len(raw_dataframe.columns))
-        raw_ws.set_column('C:C', 32)
-        raw_ws.set_column('D:D', 13)
-        raw_ws.set_column('F:F', 23)
-        raw_ws.set_column('G:G', 17)
-        raw_ws.set_column('H:H', 17)
-        raw_ws.set_column('I:I', 34)
-        raw_ws.set_column('J:J', 17)
-        raw_ws.set_column('K:K', 14)
-        raw_ws.set_column('L:L', 14)
-        raw_ws.set_column('M:M', 14)
-        raw_ws.set_column('N:N', 14)
-        raw_ws.set_column('O:O', 14)
-        
-        image_summary_ws.set_column('A2:A', 34)
-        image_summary_ws.set_column('B:B', 36, name_format)
-        image_summary_ws.set_column('C:C', 21, pct_format)
-        image_summary_ws.set_column('D:D', 26, pct_format)
-
-        user_summary_ws.set_column('A2:A', 34)
-        user_summary_ws.set_column('B:B', 13, name_format)
-        user_summary_ws.set_column('C:C', 17)
-        user_summary_ws.set_column('D:D', 17)
-        user_summary_ws.set_column('E:E', 17)
-        user_summary_ws.set_column('F:F', 21)
-        user_summary_ws.set_column('G:G', 21)
-
-        return (image_summary_data, writer)
-
-    def list(self, request, *args, **kwargs):
-        """
-        """
-        query_params = self.request.query_params
-        if not query_params.items():
-            return failure_response(status.HTTP_400_BAD_REQUEST, "The reporting API should be accessed via the query parameters: ['start_date', 'end_date', 'provider_id']")
-        return super(ReportingViewSet, self).list(request, *args, **kwargs)
 
     def get_renderer_context(self):
         """
@@ -124,23 +49,151 @@ class ReportingViewSet(AuthViewSet):
             'kwargs': getattr(self, 'kwargs', {}),
             'request': getattr(self, 'request', None),
             'filename': 'reporting.xlsx',
-            'writer_callback': self.write_excel,
+            'excel_writer_hook': self.create_excel_file,
+            'headers_ordering': ["id", "instance_id", "username", "staff_user", "provider", "start_date", "end_date", "image_name", "version_name", "size.active", "size.start_date", "size.end_date", "size.name", "size.id", "size.uuid", "size.url", "size.alias", "size.cpu", "size.mem", "size.disk", "is_featured_image", "hit_active", "hit_deploy_error", "hit_error", "hit_aborted", "hit_active_or_aborted", "hit_active_or_aborted_or_error"],
         }
 
-    def _filter_by_request(self):
+    def create_excel_file(self, raw_dataframe, writer):
+        # Return if dataframe is empty
+        if len(raw_dataframe.index) <= 1:
+            return None
+        new_datasets = self._create_datasets(raw_dataframe, writer)
+        writer = self._format_and_print_workbook(writer, new_datasets)
+        return writer
+
+    def _create_datasets(self, raw_dataframe, writer):
+        raw_dataframe['start_date'] = raw_dataframe['start_date'].apply(pd.to_datetime)
+        raw_dataframe['end_date'] = raw_dataframe['end_date'].apply(pd.to_datetime)
+
+        # Create some new tables
+        global_summary_data = raw_dataframe.set_index('start_date').query('is_featured_image == 1').resample('MS').aggregate([np.mean, np.sum])
+        user_summary_data = raw_dataframe.query('is_featured_image == 1').set_index(['start_date', 'username'])
+        image_summary_data = raw_dataframe.query('is_featured_image == 1').set_index(['start_date', 'image_name'])
+
+        # Group things, filter things, drop unneeded columns, rename things
+        global_summary_data = global_summary_data.drop(['is_featured_image', 'hit_active', 'hit_aborted', 'hit_deploy_error', 'hit_error', 'id', 'size.active', 'size.cpu', 'size.disk', 'size.id', 'size.mem'], axis=1)
+        global_summary_data.index.rename('Start Date', inplace=True)
+        global_summary_data.columns = [
+            'Average of Active/Aborted', 'Sum of Active/Aborted',
+            'Average of Active/Aborted/Error', 'Sum of Active/Aborted/Error'
+        ]
+
+        user_summary_data = user_summary_data.groupby([pd.Grouper(freq='MS', level=0), user_summary_data.index.get_level_values(1)]).aggregate([np.mean, np.sum])
+        user_summary_data = user_summary_data.drop(['is_featured_image', 'hit_error', 'id', 'size.active', 'size.cpu', 'size.disk', 'size.id', 'size.mem'], axis=1)
+        user_summary_data.index.rename(['Start Date', 'Username'], inplace=True)
+        user_summary_data.columns = [
+            'Average of Active', 'Sum of Active',
+            'Average of Aborted', 'Sum of Aborted',
+            'Average of Deploy Error', 'Sum of Deploy Error',
+            'Average of Active/Aborted', 'Sum of Active/Aborted',
+            'Average of Active/Aborted/Error', 'Sum of Active/Aborted/Error'
+        ]
+
+        image_summary_data = image_summary_data.groupby([pd.Grouper(freq='MS', level=0), image_summary_data.index.get_level_values(1)]).aggregate([np.mean, np.sum])
+        image_summary_data = image_summary_data.drop(['is_featured_image', 'hit_active', 'hit_aborted', 'hit_deploy_error', 'hit_error', 'id', 'size.active', 'size.cpu', 'size.disk', 'size.id', 'size.mem'], axis=1)
+        image_summary_data.index.rename(['Start Date', 'Image Name'], inplace=True)
+        image_summary_data.columns = [
+            'Average of Active/Aborted', 'Sum of Active/Aborted',
+            'Average of Active/Aborted/Error', 'Sum of Active/Aborted/Error'
+        ]
+        raw_dataframe = raw_dataframe.drop(['size.id', 'size.uuid', 'size.alias', 'size.active', 'size.start_date', 'size.end_date','size.url'], axis=1)
+
+        return {
+            'User Summary': user_summary_data,
+            'Image Summary': image_summary_data,
+            'Global Summary': global_summary_data,
+            'Raw Data': raw_dataframe
+        }
+
+    def _format_and_print_workbook(self, writer, new_datasets):
+        raw_dataframe = new_datasets['Raw Data']
+        user_summary_data = new_datasets['User Summary']
+        image_summary_data = new_datasets['Image Summary']
+        global_summary_data = new_datasets['Global Summary']
+
+        #Write summary data to the writer
+        writer.datetime_format = 'mmm yyyy'
+        global_summary_data.to_excel(writer, 'Monthly Summary')
+        image_summary_data.to_excel(writer, 'Image Summary')
+        user_summary_data.to_excel(writer, 'User Summary')
+
+        writer.datetime_format = 'mmm d yyyy hh:mm:ss'
+        raw_dataframe.to_excel(writer, sheet_name='Raw Data')
+
+        # FORMAT content:
+        workbook = writer.book
+        pct_format = workbook.add_format({'num_format': '0.00%'})
+        name_format = workbook.add_format()
+        name_format.set_align('left')
+
+        raw_ws = writer.sheets['Raw Data']
+        global_summary_ws = writer.sheets['Monthly Summary']
+        image_summary_ws = writer.sheets['Image Summary']
+        user_summary_ws = writer.sheets['User Summary']
+
+        # Add sort/filter around the raw data
+        row_total = len(raw_dataframe.values)
+        col_total = len(raw_dataframe.columns)
+        raw_ws.autofilter(
+            0, 0,
+            row_total, col_total)
+
+        # Format column widths on the worksheets
+        raw_ws.set_column('C:C', 32)
+        raw_ws.set_column('D:D', 13)
+        raw_ws.set_column('F:F', 23)
+        raw_ws.set_column('G:G', 17)
+        raw_ws.set_column('H:H', 17)
+        raw_ws.set_column('I:I', 34)
+        raw_ws.set_column('J:J', 17)
+        raw_ws.set_column('K:K', 14)
+        raw_ws.set_column('L:L', 14)
+        raw_ws.set_column('M:M', 14)
+        raw_ws.set_column('N:N', 14)
+        raw_ws.set_column('O:O', 14)
+
+        global_summary_ws.set_column('A:A', 34)
+        global_summary_ws.set_column('B:B', 21, pct_format)
+        global_summary_ws.set_column('D:D', 26, pct_format)
+
+        image_summary_ws.set_column('A:A', 34)
+        image_summary_ws.set_column('B:B', 36, name_format)
+        image_summary_ws.set_column('C:C', 21, pct_format)
+        image_summary_ws.set_column('E:E', 26, pct_format)
+
+        user_summary_ws.set_column('A:A', 34)
+        user_summary_ws.set_column('B:B', 13, name_format)
+        user_summary_ws.set_column('C:C', 17, pct_format)
+        user_summary_ws.set_column('E:E', 17, pct_format)
+        user_summary_ws.set_column('G:G', 21, pct_format)
+        user_summary_ws.set_column('I:I', 21, pct_format)
+        user_summary_ws.set_column('K:K', 26, pct_format)
+
+        # "Print" the writer to complete the StringIO Buffer
+        writer.save()
+
+        return writer
+
+    def get_queryset(self):
         request_user = self.request.user
         if request_user.is_staff or request_user.is_superuser:
             instances_qs = Instance.objects.all()
-        else:
+        elif request_user.is_authenticated():
             instances_qs = Instance.for_user(request_user)
         query_params = self.request.query_params
+        query = self.get_filter_query(query_params)
+
+        queryset = instances_qs.filter(query)
+        return queryset
+
+    def get_filter_query(self, query_params):
         query = Q()
 
         if 'provider_id' in query_params:
             provider_id_list = query_params.getlist('provider_id')
             provider_ids = [int(pid) for pid in provider_id_list]
             query &= Q(created_by_identity__provider__id__in=provider_ids)
-        #NOTE: All times assumed UTC.. Trust me on this one.
+        # NOTE: All times assumed UTC.. Trust me on this one.
         if 'start_date' in query_params:
             start_date = parse(query_params['start_date']).replace(tzinfo=pytz.utc)
             query &= Q(start_date__gt=start_date)
@@ -148,13 +201,19 @@ class ReportingViewSet(AuthViewSet):
         if 'end_date' in query_params:
             end_date = parse(query_params['end_date']).replace(tzinfo=pytz.utc)
             query &= Q(start_date__lt=end_date)
-
-        instances_qs = Instance.objects.filter(query)
-        return instances_qs
-
-    def get_queryset(self):
-        return self._filter_by_request()
+        return query
 
     def get(self, request, pk=None):
+        """
+        Force an abnormal behavior for 'details' calls (force a list call)
+        """
         return self.list(request)
 
+    def list(self, request, *args, **kwargs):
+        """
+        Force an abnormal behavior when no query_params are passed
+        """
+        query_params = self.request.query_params
+        if not query_params.items():
+            return failure_response(status.HTTP_400_BAD_REQUEST, "The reporting API should be accessed via the query parameters: ['start_date', 'end_date', 'provider_id']")
+        return super(ReportingViewSet, self).list(request, *args, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ djangorestframework-yaml==1.0.2
 djangorestframework-csv
 numpy
 pandas
+xlsxwriter
 django-filter==0.13.0
 django-redis-cache==0.13.0
 redis==2.10.3
@@ -34,7 +35,6 @@ python-logstash==0.4.5
 psycopg2==2.5.4
 python-ldap==2.4.19
 uWSGI==2.0.13
-xlwt
 
 ## ours
 chromogenic==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,9 @@ djangorestframework==3.4.1
 djangorestframework-jsonp==1.0.0
 djangorestframework-xml==1.0.1
 djangorestframework-yaml==1.0.2
+djangorestframework-csv
+numpy
+pandas
 django-filter==0.13.0
 django-redis-cache==0.13.0
 redis==2.10.3
@@ -31,6 +34,7 @@ python-logstash==0.4.5
 psycopg2==2.5.4
 python-ldap==2.4.19
 uWSGI==2.0.13
+xlwt
 
 ## ours
 chromogenic==0.3.1

--- a/service/instance.py
+++ b/service/instance.py
@@ -942,7 +942,7 @@ def boot_volume_instance(
     kwargs.update(prep_kwargs)
     instance, token, password = _boot_volume(
         driver, identity, copy_source, size,
-        name, userdata, network, **kwargs)
+        name, userdata, network, **prep_kwargs)
     return _complete_launch_instance(
         driver, identity, instance,
         identity.created_by, token, password, deploy=deploy)


### PR DESCRIPTION
Highlight Reel:
- [x] Create an API that allows detailed reporting of instances for external reporters (Staff members required to get all instances.)
- [x] Create a new renderer to generate Excel files (via xlsxwriter)
- [x] Re-use the CSV renderer from `restframework_csv`
- [x] Add a 'global' summary, a 'per image' summary, and a 'per user' summary, all grouped by `frequency` query_param (default, monthly).
