### PR TITLE
Problem: Atmosphere Django tests are slow

### DIFF
--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -195,7 +195,10 @@ DATABASES = {
         'CONN_MAX_AGE': {{ DATABASE_CONN_MAX_AGE }},
         'PASSWORD': '{{ DATABASE_PASSWORD }}',
         'HOST': '{{ DATABASE_HOST }}',
-        'PORT': {{ DATABASE_PORT }}
+        'PORT': {{ DATABASE_PORT }},
+        'TEST': {
+            'SERIALIZE': False
+        }
     },
 }
 


### PR DESCRIPTION
Solution: Disable database serialization. We don't need it, and it slows things down. See: https://docs.djangoproject.com/en/1.10/ref/settings/#serialize