### PR TITLE
Problem: Jetstream allocation source usage appears too high

### DIFF
--- a/jetstream/tasks.py
+++ b/jetstream/tasks.py
@@ -134,12 +134,12 @@ def send_reports():
 
 
 @task(name="update_snapshot")
-def update_snapshot():
+def update_snapshot(start_date=None, end_date=None):
     if not settings.USE_ALLOCATION_SOURCE:
         return False
-    end_date = timezone.now()
+    end_date = end_date or timezone.now()
     # TODO: Read this start_date from last 'reset event' for each allocation source
-    start_date = '2016-09-01T00:00+00:00'
+    start_date = start_date or '2016-09-01 00:00:00.0-05'
     all_data = create_report(start_date, end_date)
 
     user_allocation_snapshots = {}


### PR DESCRIPTION
Solution: We should be treating TAS as the source of truth, instead of calculating it ourselves.

- Integrated and refactored @amit4111989's code for using the TAS API as source of truth
- I have some offline tests with production data which give me confidence in these new calculations, but I would still like to create tests using test data
- Modified signature of `update_snapshot` so I can pass in start & end dates

TODO:
- Corrective reports
- Tests with clean test data
