### PR TITLE
Faster update snapshot hotfix burn rate

### DIFF
--- a/jetstream/tasks.py
+++ b/jetstream/tasks.py
@@ -133,6 +133,19 @@ def send_reports():
         raise Exception("%s/%s reports failed to send to TAS" % (failed_reports, count))
 
 
+def _get_instance_burn_rate_from_row(row):
+    burn_rate = 0
+    is_active = row['instance_status'] == 'active'
+    if is_active:
+        no_end_date = not row['instance_status_end_date']
+        ends_after_report_end = row['instance_status_end_date'] >= row['report_end_date']
+        starts_before_report_end = row['instance_status_start_date'] < row['report_end_date']
+        is_running_at_report_end = no_end_date or (starts_before_report_end and ends_after_report_end)
+        if is_running_at_report_end:
+            burn_rate = row['cpu']
+    return burn_rate
+
+
 @task(name="update_snapshot")
 def update_snapshot(start_date=None, end_date=None):
     if not settings.USE_ALLOCATION_SOURCE:
@@ -147,10 +160,11 @@ def update_snapshot(start_date=None, end_date=None):
 
     for row in all_data:
         key = (row['allocation_source'], row['username'])
-        compute_used, burn_rate = user_allocation_snapshots.get(key, (0.0, 0))
+        compute_used, instance_burn_rates = user_allocation_snapshots.get(key, (0.0, {}))
         new_compute_used = compute_used + float(row['applicable_duration'])
-        new_burn_rate = int(row['burn_rate'])
-        user_allocation_snapshots[key] = (new_compute_used, new_burn_rate)
+        new_instance_burn_rate = int(_get_instance_burn_rate_from_row(row))
+        instance_burn_rates['instance_id'] = new_instance_burn_rate
+        user_allocation_snapshots[key] = (new_compute_used, instance_burn_rates)
 
         unique_usernames.add(row['username'])
 
@@ -162,21 +176,22 @@ def update_snapshot(start_date=None, end_date=None):
     allocation_source_burn_rates = collections.Counter()
     for key, snapshot_numbers in user_allocation_snapshots.iteritems():
         allocation_source_name, username = key
-        compute_used, burn_rate = snapshot_numbers
+        compute_used, instance_burn_rates = snapshot_numbers
         try:
             allocation_source_id = allocation_source_ids[allocation_source_name]
         except KeyError:
             # This allocation source does not exist in our database yet. Create it? Skip for now. Could be 'N/A' as well
             continue
+        user_allocation_burn_rate = sum(instance_burn_rates.values())
         snapshot, created = UserAllocationSnapshot.objects.update_or_create(
             allocation_source_id=allocation_source_id,
             user_id=relevant_users[username],
             defaults={
                 'compute_used': round(compute_used / 3600, 2),
-                'burn_rate': burn_rate
+                'burn_rate': user_allocation_burn_rate
             }
         )
-        allocation_source_burn_rates[allocation_source_name] += burn_rate
+        allocation_source_burn_rates[allocation_source_name] += user_allocation_burn_rate
 
     tas_api_obj = TASAPIDriver()
     allocation_source_usage_from_tas = tas_api_obj.get_all_projects()

--- a/service/allocation_logic.py
+++ b/service/allocation_logic.py
@@ -221,3 +221,16 @@ def write_csv(data):
                 row['report_end_date'],
                 row['instance_status'],
                 row['duration'], row['applicable_duration']))
+
+
+def get_instance_burn_rate_from_row(row):
+    burn_rate = 0
+    is_active = row['instance_status'] == 'active'
+    if is_active:
+        no_end_date = not row['instance_status_end_date']
+        ends_after_report_end = row['instance_status_end_date'] >= row['report_end_date']
+        starts_before_report_end = row['instance_status_start_date'] < row['report_end_date']
+        is_running_at_report_end = no_end_date or (starts_before_report_end and ends_after_report_end)
+        if is_running_at_report_end:
+            burn_rate = row['cpu']
+    return burn_rate


### PR DESCRIPTION
Problem: Jetstream allocation source burn rate appears high

Solution: Re-calculate burn rate per user/allocation/instance.

I misunderstood the burn rate column in the report rows. It was returning the cumulative burn rate. I added a separate calculation.