### PR TITLE
Change old reference from quota.identitymembership to quota.identity

### DIFF
--- a/core/models/quota.py
+++ b/core/models/quota.py
@@ -347,7 +347,6 @@ def _pre_cache_sizes(driver):
 
 def get_quota(identity_uuid):
     try:
-        return Quota.objects.get(
-            identitymembership__identity__uuid=identity_uuid)
+        return Quota.objects.get(identity__uuid=identity_uuid)
     except Quota.DoesNotExist:
         return None


### PR DESCRIPTION
Creating a volume threw an api error because it would check a user's quota.
This fixes get_quota for an identity.